### PR TITLE
Fix for Update From Tag function crash

### DIFF
--- a/source/puddlestuff/functions.py
+++ b/source/puddlestuff/functions.py
@@ -40,6 +40,7 @@ import re
 import string
 import traceback
 import unicodedata
+from mutagen.mp3 import HeaderNotFoundError
 from collections import defaultdict
 from functools import partial
 
@@ -1038,6 +1039,8 @@ def update_from_tag(r_tags, fields, tag='APEv2'):
         if tag is None:
             return
     except EnvironmentError:
+        return
+    except mutagen.mp3.HeaderNotFoundError:
         return
     fields = [_f for _f in [z.strip() for z in fields.split(';')] if _f]
     if not fields:


### PR DESCRIPTION
1. Select at least 3 files (that aren't mp3)
2. Open Functions window and select 'Update From Tag'
3. Select ID3 from Tag dropdown and click OK

puddletag crashes with a `mutagen.mp3.HeaderNotFoundError`.
This adds a `except` statement to prevent this.