### PR TITLE
Fix for masstagging search button crash

### DIFF
--- a/source/puddlestuff/masstag/dialogs.py
+++ b/source/puddlestuff/masstag/dialogs.py
@@ -621,6 +621,12 @@ class MassTagWindow(QWidget):
 
     def _start(self):
         mtp = self.profile
+        if self.profile == None:
+            set_status(translate('Masstagging',
+                                 '<b>Please choose a tagging profile.</b>'))
+            self._startButton.setText(translate('Masstagging', '&Search'))
+            return None
+
         tag_groups = split_files(self._status['selectedfiles'],
                                  mtp.file_pattern)
 


### PR DESCRIPTION
1. Open puddletag and open mass tagging panel
2. Click search without selecting a profile.

puddletag crashes with an:

`AttributeError: 'NoneType' object has no attribute 'file_pattern'`

This adds a type check to see if a profile has actually been loaded.
If not then it displays a message to remind the user to load one and returns None.