### PR TITLE
Fix for read-only file crash

### DIFF
--- a/source/puddlestuff/puddletag.py
+++ b/source/puddlestuff/puddletag.py
@@ -741,6 +741,14 @@ class MainWin(QMainWindow):
                     if update:
                         lib_updates.append(update)
                     yield None
+                except PermissionError as e:
+                    failed_rows.append(row)
+                    filename = model.taginfo[row][PATH]
+                    m = rename_error_msg(e, filename)
+                    if row == rows[-1]:
+                        yield m, 1
+                    else:
+                        yield m, len(rows)
                 except EnvironmentError as e:
                     failed_rows.append(row)
                     filename = model.taginfo[row][PATH]
@@ -766,7 +774,6 @@ class MainWin(QMainWindow):
 
                 model.updateTable(failed_rows)
             return fin()
-
         return func, finished, rows
 
     def writeTags(self, tagiter, rows=None, previews=None):

--- a/source/puddlestuff/tagmodel.py
+++ b/source/puddlestuff/tagmodel.py
@@ -1099,7 +1099,10 @@ class TagModel(QAbstractTableModel):
             return
         else:
             artist = audio.get('artist', '')
-            undo_val = write(audio, tags, self.saveModification, justrename)
+            try:
+                undo_val = write(audio, tags, self.saveModification, justrename)
+            except PermissionError as e:
+                raise e
             if undo and undo_val:
                 self._addUndo(audio, undo_val)
 

--- a/source/puddlestuff/util.py
+++ b/source/puddlestuff/util.py
@@ -7,6 +7,7 @@ from copy import copy, deepcopy
 from errno import EEXIST
 from operator import itemgetter
 from xml.sax.saxutils import escape as escape_html
+from mutagen import MutagenError
 
 from PyQt5.QtWidgets import QAction
 
@@ -323,6 +324,10 @@ def write(audio, tags, save_mtime=True, justrename=False):
         audio.update(undo)
         audio.preview = preview
         raise
+    
+    except MutagenError as err:
+        audio.update(undo)
+        logging.exception(err)
 
     try:
         if save_mtime:


### PR DESCRIPTION
Added import for MutagenError to catch the exception.
With these changes no tags are written to the file in theevent of a mutagen error, but the trace is still output tothe console.

~~A nice addition would be a dialog warning that the files are
read-only when trying to write tags. (I am not versed in PyQt,
otherwise I would do it myself.)~~

An error dialog is now displayed when a file has a permission error.

Fixes #546

Fixes #628