### PR TITLE
Fixes for action dialog crashes

### DIFF
--- a/source/puddlestuff/actiondlg.py
+++ b/source/puddlestuff/actiondlg.py
@@ -596,6 +596,10 @@ class CreateAction(QDialog):
         self.buttonlist.duplicate.connect(self.duplicate)
         self.listbox.currentRowChanged.connect(self.enableEditButtons)
         self.listbox.itemDoubleClicked.connect(self.edit)
+        
+        if len(self.functions) == 0:
+            self.buttonlist.duplicateButton.setEnabled(False)
+            self.buttonlist.editButton.setEnabled(False)
 
         if prevfunctions is not None:
             self.functions = copy(prevfunctions)

--- a/source/puddlestuff/puddleobjects.py
+++ b/source/puddlestuff/puddleobjects.py
@@ -1218,6 +1218,8 @@ class ListBox(QListWidget):
         if not yourlist:
             yourlist = self.yourlist
         rows = sorted(rows)
+        if len(rows) == 0:
+            rows.append(0)
         lastindex = rows[0]
         groups = {lastindex: [lastindex]}
         lastrow = lastindex


### PR DESCRIPTION
### Fix for crash when pressing Edit button in Action dialog

Adds a conditional check in the CreateAction class (line 566 - source/puddlestuff/actiondlg.py)
to disable the 'Edit' and 'Duplicate' buttons when there are no
functions in the action dialog.

Steps to reproduce:

1. Open actions dialog
2. Add a new action (don't add any functions at this point)
3. Push the pencil (edit) button or the duplicate button, instead of the plus (add) button

puddletag crashes with the traceback:

```sh
Traceback (most recent call last):
  File "../puddletag/source/puddlestuff/actiondlg.py", line 659, in edit
    self.win = CreateFunction(self.functions[self.listbox.currentRow()],
IndexError: list index out of range
launch.bash: line 3:  5969 Aborted                 (core dumped) PYTHONPATH=source/ ./source/puddletag
```

### Fix for crash when pressing Down button in Action dialog

Adds a conditional check to the `moveDown` method of the `ListBox` class,
to see if the `rows` list is empty after sorting, if it is then a default value of 0 is appended.

Steps to reproduce:

1. Open actions dialog
2. Edit an action that has more than one function
3. Click the down button

puddletag crashes with an IndexError:

```sh
Traceback (most recent call last):
  File "../puddletag/source/puddlestuff/actiondlg.py", line 645, in moveDown
    self.listbox.moveDown(self.functions)
  File "../puddletag/source/puddlestuff/puddleobjects.py", line 1221, in moveDown
    lastindex = rows[0]
IndexError: list index out of range
launch.bash: line 3: 25844 Aborted                 (core dumped) PYTHONPATH=source/ ./source/puddletag
```