### PR TITLE
Fix for crash when specifying 'Export artwork to file' in action

### DIFF
--- a/source/puddlestuff/functions.py
+++ b/source/puddlestuff/functions.py
@@ -901,7 +901,7 @@ def save_artwork(m_tags, pattern, r_tags, state=None, write=True):
             i += 1
 
         if write:
-            fobj = open(fn, 'w')
+            fobj = open(fn, 'w+b')
             fobj.write(data)
             fobj.close()
         else:


### PR DESCRIPTION
Line 904 in functions.py was opening the cover as a text file,resulting in a TypeError (and crash).
This changes it from 'w' to 'w+b' (write bytes) removing the error and crash.

Fixes: #623