### PR TITLE
Fix for TypeError crash when querying MusicBrainz for tag info

### DIFF
--- a/source/puddlestuff/masstag/__init__.py
+++ b/source/puddlestuff/masstag/__init__.py
@@ -355,7 +355,10 @@ def merge_track(audio, info):
             if isinstance(info[key], str):
                 track[key] = info[key]
             else:
-                track[key] = info[key][::]
+                if isinstance(info[key], list):
+                    track[key] = info[key][::]
+                elif isinstance(info[key], dict):
+                    track[key] = info[key]
 
     for key in audio.keys():
         if not key.startswith('#'):

--- a/source/puddlestuff/masstag/dialogs.py
+++ b/source/puddlestuff/masstag/dialogs.py
@@ -490,7 +490,7 @@ class TSProfileEdit(QDialog):
 
 
 class MassTagWindow(QWidget):
-    setpreview = pyqtSignal(name='setpreview')
+    setpreview = pyqtSignal(dict, name='setpreview')
     clearpreview = pyqtSignal(name='clearpreview')
     enable_preview_mode = pyqtSignal(name='enable_preview_mode')
     writepreview = pyqtSignal(name='writepreview')


### PR DESCRIPTION
Added type checking to merge_track (in source/puddlestuff/masstag/__init__.py)
to correct the original error, also added a type parameter to the
setpreview pyqtSignal (in source/puddlestuff/puddleobjects.py) to fix another
error that arose after fixing the first one.

Fixes #527