### PR TITLE
Accept multiple file/directory names on commandline

### DIFF
--- a/source/puddlestuff/puddletag.py
+++ b/source/puddlestuff/puddletag.py
@@ -251,6 +251,12 @@ class PreviewLabel(QLabel):
         self._enabled = not self._enabled
         self.valueChanged.emit(self._enabled)
 
+def _openFilesFilterFilename(filename):
+    filename = os.path.abspath(filename)
+    if isinstance(filename, str):
+        filename = encode_fn(filename)
+    return filename
+
 
 class MainWin(QMainWindow):
     loadFiles = pyqtSignal(object, object, object, object, object, name='loadFiles')
@@ -561,6 +567,10 @@ class MainWin(QMainWindow):
                 filename = encode_fn(filename)
 
         self.loadFiles.emit(None, [filename], append, None, None)
+
+    def openFiles(self, filenames, append=False):
+        filenames = map(_openFilesFilterFilename, filenames)
+        self.loadFiles.emit(None, filenames, append, None, None)
 
     def openPrefs(self):
         win = SettingsDialog(list(PuddleDock._controls.values()), self, status)

--- a/source/puddletag
+++ b/source/puddletag
@@ -348,9 +348,11 @@ if __name__ == '__main__':
 
     # Check if dirnames passed on command line.
     if filenames:
-        dirname = filenames[0]
-        if dirname and os.path.exists(dirname):
-            win.openDir(dirname, False)
+        for filename in filenames:
+            if not os.path.exists(filename):
+                print('Directory or file %s does not exist.' % filename)
+                sys.exit(1)
+        win.openFiles(filenames, False)
     elif load_gen_settings([('&Load last folder at startup', False)])[0][1]:
         if win._lastdir and os.path.exists(win._lastdir[0]):
             win.openDir(win._lastdir[0], False)

--- a/source/puddletag.1
+++ b/source/puddletag.1
@@ -3,7 +3,7 @@
 puddletag \- puddletag
 .SH SYNOPSIS
 .B puddletag
-[\fIoptions\fR] [\fIdirectory path\fR]
+[\fIoptions\fR] [\fIfile/directory paths...\fR]
 .SH DESCRIPTION
 puddletag is an audio tag editor (primarily created) for GNU/Linux similar to the Windows program, Mp3tag. Unlike most taggers for GNU/Linux, it uses a spreadsheet-like layout so that all the tags you want to edit by hand are visible and easily editable.
 
@@ -14,8 +14,8 @@ Then there're Functions, which can do things like replace text, trim it, do case
 Supported formats: ID3v1, ID3v2 (mp3), MP4 (mp4, m4a, etc.), VorbisComments (ogg, flac), Musepack (mpc), Monkey's Audio (.ape) and WavPack (wv).
 .SH OPTIONS
 .TP
-\fBdirectory path\fR
-Path to any directory which'll be loaded on startup.
+\fBfile/directory paths...\fR
+Paths to any files or directories which'll be loaded on startup.
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Show help message and exit.
@@ -28,6 +28,13 @@ Default font size to use (in points). All UI elements except the file-view will 
 .TP
 \fB\-d\fR, \fB\-\-debug\fR
 Show (useless) debug messages. Do not use.
+.SH "INTEGRATION WITH CMUS"
+.TP
+To launch puddletag from cmus, loading all the marked files, set up a keybinding like this:
+
+.B bind common ^T run puddletag {}
+.TP
+in a configuration file such as \fI~/.config/cmus/rc\fR
 .SH "SEE ALSO"
 The puddletag website (
 .B http://puddletag.sourceforge.net


### PR DESCRIPTION
This allows running from programs such as cmus which expect a tagger to
be able to accept more than one filename or directory name. It also
makes it more convenient to launch puddletag from the command line for
ad-hoc editing of several files. Previously puddletag would simply
ignore any non-option arguments after the first one.