### PR TITLE
Fix for extended tags view bug

### DIFF
--- a/source/puddlestuff/mainwin/funcs.py
+++ b/source/puddlestuff/mainwin/funcs.py
@@ -191,11 +191,7 @@ def display_tag(tag):
 
 def extended_tags(parent=None):
     rows = status['selectedrows']
-    if len(rows) == 1:
-        win = helperwin.ExTags(parent, rows[0], status['alltags'],
-                               status['previewmode'], status=status)
-    else:
-        win = helperwin.ExTags(files=status['selectedfiles'], parent=parent)
+    win = helperwin.ExTags(files=status['selectedfiles'], parent=parent)
     win.setModal(True)
     win.rowChanged.connect(status['table'].selectRow)
     win.loadSettings()


### PR DESCRIPTION
Removed conditional that resulted in information for
all tracks being shown when only the first track of the
list is selected. The conditional didn't seem to be necessary
as my testing (after removing it) didn't reveal any degraded
functionality/crashes.

Fixes #597