### PR TITLE
Fix for crash when searching with AcoustId

### DIFF
--- a/source/puddlestuff/tagsources/_acoustid.py
+++ b/source/puddlestuff/tagsources/_acoustid.py
@@ -296,7 +296,7 @@ def _fingerprint_file_fpcalc(path, maxlength):
     duration = fp = None
     for line in output.splitlines():
         try:
-            parts = line.split('=', 1)
+            parts = str(line).split('=', 1)
         except ValueError:
             raise FingerprintGenerationError("malformed fpcalc output")
         if parts[0] == 'DURATION':

--- a/source/puddlestuff/tagsources/acoust_id.py
+++ b/source/puddlestuff/tagsources/acoust_id.py
@@ -104,10 +104,7 @@ def convert_for_submit(tags):
 
 
 def fingerprint_file(fn):
-    try:
-        return acoustid._fingerprint_file_fpcalc(fn, 120)
-    except TypeError:
-        return acoustid._fingerprint_file_fpcalc(fn)
+    return acoustid._fingerprint_file_fpcalc(fn, 120)
 
 
 def id_in_tag(tag):


### PR DESCRIPTION
Removed (seemingly) pointless `try`/`catch` that always
resulted in a `TypeError`. Also added `str` conversion in
`_fingerprint_file_fpcalc()` to avoid another error.

Fixes: #564