### PR TITLE
Allow for multiple files and directories as arguments

### DIFF
--- a/source/puddlestuff/puddletag.py
+++ b/source/puddlestuff/puddletag.py
@@ -555,8 +555,8 @@ class MainWin(QMainWindow):
             filenames = map(os.path.abspath, filename)
             filenames = list(map(encode_fn, filenames))
 
-            files = [f for f in filenames if os.path.isfile(f)] 
-            dirs  = [f for f in filenames if os.path.isdir(f)] 
+            files = set(f for f in filenames if os.path.isfile(f))
+            dirs  = set(f for f in filenames if os.path.isdir(f))
 
         self.loadFiles.emit(files, dirs, append, None, None)
 

--- a/source/puddlestuff/puddletag.py
+++ b/source/puddlestuff/puddletag.py
@@ -524,7 +524,7 @@ class MainWin(QMainWindow):
         dirname = self._lastdir[0] if self._lastdir else QDir.homePath()
         selectedFile = QFileDialog.getOpenFileName(self,
                                                    translate("Playlist", translate("Playlist", 'Select m3u file...')), )
-        filename = selectedFile[0]
+        filename = selectedFile
         if not filename:
             return
         try:
@@ -548,19 +548,17 @@ class MainWin(QMainWindow):
         Otherwise, the folder is just loaded."""
 
         if filename is None:
-            filename = self._getDir()
-            if not filename:
+            filenames = self._getDir()
+            if not filenames:
                 return
         else:
-            if not isinstance(filename, str):
-                filename = filename[0]
+            filenames = map(os.path.abspath, filename)
+            filenames = list(map(encode_fn, filenames))
 
-            filename = os.path.abspath(filename)
+            files = [f for f in filenames if os.path.isfile(f)] 
+            dirs  = [f for f in filenames if os.path.isdir(f)] 
 
-            if isinstance(filename, str):
-                filename = encode_fn(filename)
-
-        self.loadFiles.emit(None, [filename], append, None, None)
+        self.loadFiles.emit(files, dirs, append, None, None)
 
     def openPrefs(self):
         win = SettingsDialog(list(PuddleDock._controls.values()), self, status)

--- a/source/puddlestuff/tagmodel.py
+++ b/source/puddlestuff/tagmodel.py
@@ -1830,13 +1830,13 @@ class TagTable(QTableView):
 
     def loadFiles(self, files=None, dirs=None, append=False, subfolders=None,
                   filepath=None, post_process=None):
-        assert files or dirs, 'Either files or dirs (or both) must be specified.'
 
         if subfolders is None:
             subfolders = self.subFolders
 
         if not files:
             files = []
+
         if not dirs:
             dirs = []
         elif isinstance(dirs, str):

--- a/source/puddletag
+++ b/source/puddletag
@@ -348,9 +348,7 @@ if __name__ == '__main__':
 
     # Check if dirnames passed on command line.
     if filenames:
-        dirname = filenames[0]
-        if dirname and os.path.exists(dirname):
-            win.openDir(dirname, False)
+        win.openDir(filenames, True)
     elif load_gen_settings([('&Load last folder at startup', False)])[0][1]:
         if win._lastdir and os.path.exists(win._lastdir[0]):
             win.openDir(win._lastdir[0], False)


### PR DESCRIPTION
If you wished to read several files with Puddletag, you previously had
to start the GUI and load the files. If you wrote more files or
directories in the terminal as arguments for Puddletag, only the first
argument would be loaded.

This change will specify from the terminal which files and directory,
and all files specified will be read.

Minor feature. It annoyed me, so I had a look. Please point out if I missed anything.