### PR TITLE
Fix deprecated regex escape sequences in strings

### DIFF
--- a/puddlestuff/findfunc.py
+++ b/puddlestuff/findfunc.py
@@ -430,7 +430,7 @@ def parsefunc(s, m_audio, s_audio=None, state=None, extra=None, ret_i=False, pat
                 escape = False
             continue
         elif c == '$' and not (escape or (field_open >= 0)):
-            func_name = re.search('^\$(\w+)\(', s[i:])
+            func_name = re.search(r'^\$(\w+)\(', s[i:])
             if not func_name:
                 token.append(c)
                 i += 1

--- a/puddlestuff/funcprint.py
+++ b/puddlestuff/funcprint.py
@@ -50,7 +50,7 @@ def func(match, d):
                 d[number] = NO
         return d[number]
     except ValueError:
-        number = int(re.search('(\d+)', matchtext).group())
+        number = int(re.search(r'(\d+)', matchtext).group())
         if number >= len(d):
             return ''
         if d[number] is False:

--- a/puddlestuff/functions.py
+++ b/puddlestuff/functions.py
@@ -665,7 +665,7 @@ only as &whole word, check'''
         matchcase = re.IGNORECASE
     if chars is None:
         chars = r'\,\.\(\) \!\[\]'
-    replaceword = replaceword.replace(r'\\', '\\\\')
+    replaceword = replaceword.replace('\\', '\\\\')
 
     if whole:
         pat = re.compile(r'(^|[%s])%s([%s]|$)' % (chars, word, chars), matchcase)

--- a/puddlestuff/functions.py
+++ b/puddlestuff/functions.py
@@ -128,7 +128,7 @@ def caps3(text):
     # Capitalizes the first letter of the string and converts
     # the rest to lower case.
     try:
-        start = re.search("\w", text, re.U).start(0)
+        start = re.search(r"\w", text, re.U).start(0)
     except AttributeError:
         return
     return text[:start] + text[start].upper() + text[start + 1:].lower()
@@ -246,7 +246,7 @@ def grtr(text, text1):
 
 
 def to_num(text):
-    match = re.search('[\-\+]?[0-9]+(\.[0-9]+)?', text)
+    match = re.search(r'[\-\+]?[0-9]+(\.[0-9]+)?', text)
     return match.group() if match else ''
 
 
@@ -664,11 +664,11 @@ only as &whole word, check'''
     else:
         matchcase = re.IGNORECASE
     if chars is None:
-        chars = '\,\.\(\) \!\[\]'
-    replaceword = replaceword.replace('\\', '\\\\')
+        chars = r'\,\.\(\) \!\[\]'
+    replaceword = replaceword.replace(r'\\', '\\\\')
 
     if whole:
-        pat = re.compile('(^|[%s])%s([%s]|$)' % (chars, word, chars), matchcase)
+        pat = re.compile(r'(^|[%s])%s([%s]|$)' % (chars, word, chars), matchcase)
     else:
         pat = re.compile(word, matchcase)
 
@@ -703,7 +703,7 @@ class RegHelper(object):
     def repl(self, match):
         v = int(match.group()[1:])
         try:
-            if re.search('\$[\w\d_]+\(', self._repl):
+            if re.search(r'\$[\w\d_]+\(', self._repl):
                 return re_escape(self.groups[v], '"\\,')
             else:
                 return self.groups[v]
@@ -739,7 +739,7 @@ Match &Case, check"""
         else:
             d = {1: group, 0: group}
 
-        ret = re.sub('(?i)\$\d+', RegHelper(d, repl).repl, repl, 0)
+        ret = re.sub(r'(?i)\$\d+', RegHelper(d, repl).repl, repl, 0)
         return findfunc.parsefunc(ret, m_tags)
 
     def replace_matches(value):

--- a/puddlestuff/masstag/dialogs.py
+++ b/puddlestuff/masstag/dialogs.py
@@ -694,7 +694,7 @@ if __name__ == '__main__':
     mtp = MassTagProfile('Searching', 'Testing Search',
                          ['artist', 'title'], None, '%artist% - ktg',
                          [tsp], 0.70, 0.90, False, True,
-                         {'album': ['(.*?)\s+\(.*\)', '$1']})
+                         {'album': [r'(.*?)\s+\(.*\)', '$1']})
     # win = MTProfileEdit(sources, mtp)
 
     win = MassTagEdit(sources)

--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -741,7 +741,7 @@ def translate_filename_pattern(pat):
         else:
             res = res + re.escape(c)
     # return res + '\Z(?ms)'
-    return res + '\Z'
+    return res + r'\Z'
 
 
 def fnmatch(pattern, files, matchcase=False):

--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -298,7 +298,7 @@ def _Tag(model):
                in audioinfo.options]
     filetypes = dict([(z[0], z) for z in options])
 
-    extension_regex = re.compile('\.(%s)$' % '|'.join(extensions))
+    extension_regex = re.compile(r'\.(%s)$' % '|'.join(extensions))
 
     def ReplacementTag(filename):
 

--- a/puddlestuff/tagsources/__init__.py
+++ b/puddlestuff/tagsources/__init__.py
@@ -58,9 +58,9 @@ useragent = "puddletag/" + version_string
 
 def get_encoding(page, decode=False, default=None):
     encoding = None
-    match = re.search(b'<\?xml(.+)\?>', page)
+    match = re.search(r'<\?xml(.+)\?>', page)
     if match:
-        enc = re.search('''encoding(?:\s*)=(?:\s*)["'](.+?)['"]''',
+        enc = re.search(r'''encoding(?:\s*)=(?:\s*)["'](.+?)['"]''',
                         match.group(), re.I)
         if enc:
             encoding = enc.groups()[0]

--- a/puddlestuff/tagsources/amazon.py
+++ b/puddlestuff/tagsources/amazon.py
@@ -251,7 +251,7 @@ def search(artist=None, album=None):
         keywords = artist
     else:
         keywords = album
-    keywords = re.sub('(\s+)', '+', keywords)
+    keywords = re.sub(r'(\s+)', '+', keywords)
     return keyword_search(keywords)
 
 # A couple of things you should be aware of.

--- a/puddlestuff/tagsources/amg.py
+++ b/puddlestuff/tagsources/amg.py
@@ -61,7 +61,7 @@ spanmap = CaselessDict({
     'primary': 'composer',
 })
 
-sqlre = re.compile('(r\d+)$')
+sqlre = re.compile(r'(r\d+)$')
 
 first_white = lambda match: match.groups()[0][0]
 
@@ -81,7 +81,7 @@ white_replace = lambda match: match.group()[0]
 
 def convert(value):
     text = value.strip()
-    text = re.sub('\s{2,}', white_replace, text)
+    text = re.sub(r'\s{2,}', white_replace, text)
     if isinstance(text, str):
         return str(text)
     return text
@@ -110,7 +110,7 @@ def convert_year(info):
 
 def create_search(terms):
     terms = re.sub('[%]', '', terms.strip())
-    return search_adress % urllib.parse.quote(re.sub('(\s+)', ' ',
+    return search_adress % urllib.parse.quote(re.sub(r'(\s+)', ' ',
                                                      terms))
 
 
@@ -338,7 +338,7 @@ def parse_search_element(td, id_field=ALBUM_ID):
     info['#extrainfo'] = [
         info['album'] + ' at AllMusic.com', info['#albumurl']]
 
-    info[id_field] = re.search('-(mw\d+)$', info['#albumurl']).groups()[0]
+    info[id_field] = re.search(r'-(mw\d+)$', info['#albumurl']).groups()[0]
 
     return dict((k, v) for k, v in info.items() if not isempty(v))
 
@@ -528,7 +528,7 @@ def search(album):
 
 def text(z):
     text = z.all_recursive_text().strip()
-    return re.sub('(\s+)', first_white, text)
+    return re.sub(r'(\s+)', first_white, text)
 
 
 def to_file(data, name):

--- a/puddlestuff/tagsources/mp3tag/__init__.py
+++ b/puddlestuff/tagsources/mp3tag/__init__.py
@@ -51,8 +51,8 @@ MTAG_KEYS = {
 
 
 def convert_entities(s):
-    s = re.sub('&#(\d+);', lambda m: chr(int(m.groups(0)[0])), s)
-    return re.sub('&(\w)+;',
+    s = re.sub(r'&#(\d+);', lambda m: chr(int(m.groups(0)[0])), s)
+    return re.sub(r'&(\w)+;',
                   lambda m: n2cp.get(m.groups(0), '&%s;' % m.groups(0)[0]), s)
 
 
@@ -161,7 +161,7 @@ def parse_func(lineno, line):
 
 
 def parse_ident(line):
-    ident, value = re.search('^\[(\w+)\]=(.*)$', line).groups()
+    ident, value = re.search(r'^\[(\w+)\]=(.*)$', line).groups()
     return ident, value
 
 
@@ -350,7 +350,7 @@ class Mp3TagSource(object):
             keywords = format_value(files[0], self.searchby)
         else:
             keywords = artist
-        keywords = re.sub('\s+', self._separator, keywords)
+        keywords = re.sub(r'\s+', self._separator, keywords)
 
         if self.search_source is None:
             album = self.retrieve(keywords)

--- a/puddlestuff/tagsources/mp3tag/funcs.py
+++ b/puddlestuff/tagsources/mp3tag/funcs.py
@@ -258,7 +258,7 @@ def saynewline(cursor):
 
 def saynextnumber(cursor):
     try:
-        number = re.search('\d+', cursor.line[cursor.charno:]).group()
+        number = re.search(r'\d+', cursor.line[cursor.charno:]).group()
         cursor.log('Saying number %s\n' % number)
         cursor.cache += number
         cursor.charno += len(number)
@@ -267,7 +267,7 @@ def saynextnumber(cursor):
 
 
 def saynextword(cursor):
-    word = re.search('\w+', cursor.line[cursor.charno:]).group()
+    word = re.search(r'\w+', cursor.line[cursor.charno:]).group()
     cursor.cache += word
     cursor.charno += len(word)
 

--- a/puddlestuff/translations.py
+++ b/puddlestuff/translations.py
@@ -9,7 +9,7 @@ class UnicodeMod(str):
     than the translate function above."""
 
     def arg(self, value):
-        matches = [z for z in re.finditer("%(\d+)", self)]
+        matches = [z for z in re.finditer(r"%(\d+)", self)]
         if not matches:
             logging.error('Undefined result for arg.')
             return UnicodeMod(self[::])

--- a/puddlestuff/webdb.py
+++ b/puddlestuff/webdb.py
@@ -48,7 +48,7 @@ FIELDLIST_TIP = translate("WebDB",
                           '__image</b> will write all fields but the '
                           'composer and __image fields.')
 
-DEFAULT_REGEXP = {'album': ['(.*?)([\(\[\{].*[\)\]\}])', '$1']}
+DEFAULT_REGEXP = {'album': [r'(.*?)([\(\[\{].*[\)\]\}])', '$1']}
 
 
 def apply_regexps(audio, regexps=None):


### PR DESCRIPTION
In support of the ongoing adoption of Unicode within Python, [bug # 27364
(2016)][1] deprecates "invalid" (read: regular expression) escape
sequences outside the use of raw strings in Python 3.6+.

This was discovered when performing Flake8 analysis on the code base and
discovering a number of [`W605`][2] warnings thrown.

Due to the fact that, eventually, this will transition from
`DeprecationWarning` to `SyntaxError` this change set resolves all
outstanding `W605` warnings with no other changes made.

Subsequently, as a number if issues have been raised which involve
encoding issues with Unicode and marshalling between strings and bytes
(e.g. #541, #551, #556, #595) some of these regular expression strings
may _also_ need to be changed to [byte literals][3] (i.e. prefixing the
string with `b`).

[1]: https://bugs.python.org/issue27364
[2]: https://www.flake8rules.com/rules/W605.html
[3]: https://docs.python.org/3/library/stdtypes.html#bytes