### PR TITLE
BUG: fix Shift+Enter behavior

### DIFF
--- a/source/puddlestuff/tagmodel.py
+++ b/source/puddlestuff/tagmodel.py
@@ -1272,7 +1272,7 @@ class TagDelegate(QStyledItemDelegate):
     def eventFilter(self, editor, event):
         if event.type() == QEvent.KeyPress:
             if event.key() in (Qt.Key_Return, Qt.Key_Enter):
-                if event.modifiers() == Qt.ShiftModifier:
+                if event.modifiers() & Qt.ShiftModifier:
                     editor.returnPressed = SHIFT_RETURN
                 else:
                     editor.returnPressed = RETURN_ONLY

--- a/source/puddlestuff/tagmodel.py
+++ b/source/puddlestuff/tagmodel.py
@@ -1272,7 +1272,11 @@ class TagDelegate(QStyledItemDelegate):
     def eventFilter(self, editor, event):
         if event.type() == QEvent.KeyPress:
             if event.key() in (Qt.Key_Return, Qt.Key_Enter):
-                if event.modifiers() & Qt.ShiftModifier:
+                if event.key() == Qt.Key_Return:
+                    shift_pressed = event.modifiers() == Qt.ShiftModifier
+                else:
+                    shift_pressed = event.modifiers() == Qt.ShiftModifier | Qt.KeypadModifier
+                if shift_pressed:
                     editor.returnPressed = SHIFT_RETURN
                 else:
                     editor.returnPressed = RETURN_ONLY


### PR DESCRIPTION
I encountered an issue with "Shift + Enter" not behaving equivalently to "Shift + Return" (Enter is located on the numeric keypad).

When the Shift + Enter is pressed both `Qt.ShiftModifier` and `Qt.KeypadModifier` modifiers are set, causing the current check for `events.modifiers() == Qt.ShiftModifier` to return False. This leads to the shift modifier being ignored. 

The fix implemented here is just to check that Qt.ShiftModifiers is among the modifiers that are set. An alternative solution if you want to rule out additional modifiers is to use something like:
```Python
                if event.key() == Qt.Key_Return:
                    shift_pressed = event.modifiers() == Qt.ShiftModifier
                else:
                    shift_pressed = event.modifiers() == Qt.ShiftModifier | Qt.KeypadModifier
                if shift_pressed:
                    editor.returnPressed = SHIFT_RETURN
```

if you prefer that, let me know and I will update the PR.