### PR TITLE
Fixed error with empty separator in split field function

### DIFF
--- a/source/puddlestuff/functions.py
+++ b/source/puddlestuff/functions.py
@@ -925,7 +925,10 @@ def split_by_sep(m_text, sep):
     else:
         ret = []
         for t in m_text:
-            ret.extend(t.split(sep))
+            try:
+                ret.extend(t.split(sep))
+            except ValueError:
+                ret.append(t)
         return ret
 
 


### PR DESCRIPTION
When no separator parameter is provided for function *Split field using operator* (which happens when one deletes default content of a textbox), uncaught `ValueError` is thrown, resulting in the application shutdown.

The error is now caught and function returns unchanged parameter.

Resolves #641 