### PR TITLE
m3u vs m3u8 encoding

### DIFF
--- a/source/puddlestuff/m3u.py
+++ b/source/puddlestuff/m3u.py
@@ -1,5 +1,6 @@
 import csv
 import os
+import re
 import sys
 from os.path import abspath, dirname, normcase, normpath, splitdrive
 from os.path import join as path_join
@@ -77,8 +78,14 @@ def relpath(target, base_path=os.curdir):
 
 def readm3u(path):
     # From http://forums.fedoraforum.org/showthread.php?p=1224109
-    fileHandle = open(path, 'r')
-    reader = csv.reader(open(path, "r"))
+
+    # m3u commonly uses non-utf8 encoding, m3u8 is the utf8 equivalent
+    if (re.match(r".*\.m3u$", path)):
+        fileHandle = open(path, 'r', encoding='latin9')
+    else:
+        fileHandle = open(path, 'r', encoding='utf-8')
+
+    reader = csv.reader(fileHandle)
     olddir = os.path.abspath(os.curdir)
     os.chdir(os.path.dirname(path))
 

--- a/source/puddlestuff/puddlesettings.py
+++ b/source/puddlestuff/puddlesettings.py
@@ -223,7 +223,7 @@ class Playlist(QWidget):
         self.windows_separator.setCheckState(inttocheck(cparser.load('playlist', 'windows_separator', 0, True)))
 
         self.filename = QLineEdit()
-        self.filename.setText(cparser.load('playlist', 'filepattern', 'puddletag.m3u'))
+        self.filename.setText(cparser.load('playlist', 'filepattern', 'puddletag.m3u8'))
         label = QLabel(translate("Playlist Settings", '&Filename pattern.'))
         label.setBuddy(self.filename)
 

--- a/source/puddlestuff/puddletag.py
+++ b/source/puddlestuff/puddletag.py
@@ -681,7 +681,7 @@ class MainWin(QMainWindow):
             dirname = self._lastdir[0]
         except IndexError:
             dirname = constants.HOMEDIR
-        filepattern = settings.get('playlist', 'filepattern', 'puddletag.m3u')
+        filepattern = settings.get('playlist', 'filepattern', 'puddletag.m3u8')
         default = encode_fn(findfunc.tagtofilename(filepattern, tags[0]))
         selectedFile = QFileDialog.getSaveFileName(self,
                                                    translate("Playlist", 'Save Playlist...'), os.path.join(dirname, default))


### PR DESCRIPTION
- Read m3u files in latin9 encoding, any other with utf-8
- Change the default file ending for exporting from m3u to m3u8

m3u commonly uses latin1/latin9 encoding, which results in
csv.reader() to fail when unicode characters (ä/ö/ü/...) are contained.
The unicode equivalent file ending is called m3u8.

While the default for new exports will be changed for new installations,
unfortunately the legacy name (puddletag.m3u) will not be overridden.
This might cause issues when you will export a playlist as m3u despite
the utf8 suffix and try to reimport it.

An alternative would be to be able to choose the encoding during import in some way.
The export suffix should be changed to m3u8 in any way because utf8 is
the exported encoding.