### PR TITLE
lxml package is needed by AllMusic TagSource

### DIFF
--- a/source/requirements.txt
+++ b/source/requirements.txt
@@ -7,3 +7,4 @@ pyqt5==5.15
 configobj==5.0
 mutagen==1.45
 pyparsing==2.4.7
+lxml==4.7.1


### PR DESCRIPTION
Fixes one of the issues described in https://github.com/puddletag/puddletag/issues/666