### PR TITLE
Fix tagsources get_encoding

### DIFF
--- a/source/puddlestuff/actiondlg.py
+++ b/source/puddlestuff/actiondlg.py
@@ -596,6 +596,10 @@ class CreateAction(QDialog):
         self.buttonlist.duplicate.connect(self.duplicate)
         self.listbox.currentRowChanged.connect(self.enableEditButtons)
         self.listbox.itemDoubleClicked.connect(self.edit)
+        
+        if len(self.functions) == 0:
+            self.buttonlist.duplicateButton.setEnabled(False)
+            self.buttonlist.editButton.setEnabled(False)
 
         if prevfunctions is not None:
             self.functions = copy(prevfunctions)

--- a/source/puddlestuff/puddleobjects.py
+++ b/source/puddlestuff/puddleobjects.py
@@ -1218,6 +1218,8 @@ class ListBox(QListWidget):
         if not yourlist:
             yourlist = self.yourlist
         rows = sorted(rows)
+        if len(rows) == 0:
+            rows.append(0)
         lastindex = rows[0]
         groups = {lastindex: [lastindex]}
         lastrow = lastindex

--- a/source/puddlestuff/puddletag.py
+++ b/source/puddlestuff/puddletag.py
@@ -741,6 +741,14 @@ class MainWin(QMainWindow):
                     if update:
                         lib_updates.append(update)
                     yield None
+                except PermissionError as e:
+                    failed_rows.append(row)
+                    filename = model.taginfo[row][PATH]
+                    m = rename_error_msg(e, filename)
+                    if row == rows[-1]:
+                        yield m, 1
+                    else:
+                        yield m, len(rows)
                 except EnvironmentError as e:
                     failed_rows.append(row)
                     filename = model.taginfo[row][PATH]
@@ -766,7 +774,6 @@ class MainWin(QMainWindow):
 
                 model.updateTable(failed_rows)
             return fin()
-
         return func, finished, rows
 
     def writeTags(self, tagiter, rows=None, previews=None):

--- a/source/puddlestuff/tagmodel.py
+++ b/source/puddlestuff/tagmodel.py
@@ -1275,7 +1275,11 @@ class TagDelegate(QStyledItemDelegate):
     def eventFilter(self, editor, event):
         if event.type() == QEvent.KeyPress:
             if event.key() in (Qt.Key_Return, Qt.Key_Enter):
-                if event.modifiers() & Qt.ShiftModifier:
+                if event.key() == Qt.Key_Return:
+                    shift_pressed = event.modifiers() == Qt.ShiftModifier
+                else:
+                    shift_pressed = event.modifiers() == Qt.ShiftModifier | Qt.KeypadModifier
+                if shift_pressed:
                     editor.returnPressed = SHIFT_RETURN
                 else:
                     editor.returnPressed = RETURN_ONLY

--- a/source/puddlestuff/tagmodel.py
+++ b/source/puddlestuff/tagmodel.py
@@ -1099,7 +1099,10 @@ class TagModel(QAbstractTableModel):
             return
         else:
             artist = audio.get('artist', '')
-            undo_val = write(audio, tags, self.saveModification, justrename)
+            try:
+                undo_val = write(audio, tags, self.saveModification, justrename)
+            except PermissionError as e:
+                raise e
             if undo and undo_val:
                 self._addUndo(audio, undo_val)
 

--- a/source/puddlestuff/tagmodel.py
+++ b/source/puddlestuff/tagmodel.py
@@ -1275,7 +1275,7 @@ class TagDelegate(QStyledItemDelegate):
     def eventFilter(self, editor, event):
         if event.type() == QEvent.KeyPress:
             if event.key() in (Qt.Key_Return, Qt.Key_Enter):
-                if event.modifiers() == Qt.ShiftModifier:
+                if event.modifiers() & Qt.ShiftModifier:
                     editor.returnPressed = SHIFT_RETURN
                 else:
                     editor.returnPressed = RETURN_ONLY

--- a/source/puddlestuff/tagsources/__init__.py
+++ b/source/puddlestuff/tagsources/__init__.py
@@ -27,12 +27,14 @@ class WebServiceError(EnvironmentError):
 
 
 class RetrievalError(WebServiceError):
+
     def __init__(self, msg, code=0):
         WebServiceError.__init__(self, msg)
         self.code = code
 
 
 class SubmissionError(WebServiceError):
+
     def __init__(self, msg, code=0):
         WebServiceError.__init__(self, msg)
         self.code = code
@@ -56,19 +58,12 @@ useragent = "puddletag/" + version_string
 
 def get_encoding(page, decode=False, default=None):
     encoding = None
-    match = re.search('<\?xml(.+)\?>', page)
+    match = re.search(b'<\?xml(.+)\?>', page)
     if match:
         enc = re.search('''encoding(?:\s*)=(?:\s*)["'](.+?)['"]''',
                         match.group(), re.I)
         if enc:
             encoding = enc.groups()[0]
-
-    if not encoding:
-        parser = MetaProcessor()
-        try:
-            parser.feed(page)
-        except FoundEncoding as e:
-            encoding = e.encoding.strip()
 
     if not encoding and default:
         encoding = default
@@ -217,6 +212,7 @@ def write_log(text):
 
 
 class MetaProcessor(HTMLParser):
+
     def reset(self):
         self.pieces = []
         self.encoding = None

--- a/source/puddlestuff/util.py
+++ b/source/puddlestuff/util.py
@@ -7,6 +7,7 @@ from copy import copy, deepcopy
 from errno import EEXIST
 from operator import itemgetter
 from xml.sax.saxutils import escape as escape_html
+from mutagen import MutagenError
 
 from PyQt5.QtWidgets import QAction
 
@@ -323,6 +324,10 @@ def write(audio, tags, save_mtime=True, justrename=False):
         audio.update(undo)
         audio.preview = preview
         raise
+    
+    except MutagenError as err:
+        audio.update(undo)
+        logging.exception(err)
 
     try:
         if save_mtime:


### PR DESCRIPTION
This method leans on the html.parser module and that by specification only accepts strings:

https://docs.python.org/3/library/html.parser.html#html.parser.HTMLParser.feed

It cannot therefore be sensibly used to divine the encoding of a byte-string and this whole block of code is  redundant. Likely a carry over from the Python 2 to 3 conversion.

Moreover I can find no reference in nay documentation to a FoundEncoding exception and no idea where that is implemented but certainly not by html.parser.