### PR TITLE
Fix bug in AllMusic tagsource

### DIFF
--- a/source/puddlestuff/tagsources/amg.py
+++ b/source/puddlestuff/tagsources/amg.py
@@ -358,9 +358,8 @@ def parse_searchpage(page, artist=None, album=None, id_field=ALBUM_ID):
 
     Return a tuple with the first element being == True if the list
     was truncated with only matching artist/albums.
-    
+
     """
-    page = get_encoding(page, True, 'utf8')[1]
     soup = parse_html.SoupWrapper(parse_html.parse(page))
     result_table = soup.find('ul', {'class': 'search-results'})
     try:
@@ -394,6 +393,7 @@ def parse_searchpage(page, artist=None, album=None, id_field=ALBUM_ID):
 
 
 def parse_track_table(table, discnum=None):
+
     def to_string(e):
         try:
             return convert(e.a.string)


### PR DESCRIPTION
get_encoding returns a string describing the encoding. To overwrite page with that is a glaring bug. Moreover the BeautifulSoup parser doesn't even care about the encoding so we don't need to divine (or if it does it works it out for itself)..

Removing this one line makes the AllMusic tagsource functional once more.

Fixes: https://github.com/puddletag/puddletag/issues/666