### PR TITLE
Fix tagsources get_encoding

### DIFF
--- a/source/puddlestuff/audio_filter.py
+++ b/source/puddlestuff/audio_filter.py
@@ -180,7 +180,7 @@ bool_exprs = [
 field_expr = Combine('%' + Word(alphanums + '_') + '%')
 tokens = QuotedString('"', unquoteResults=False) \
          | field_expr | Word(alphanums + '_')
-bool_expr = operatorPrecedence(tokens, bool_exprs)
+bool_expr = infixNotation(tokens, bool_exprs)
 bool_expr.enablePackrat()
 
 

--- a/source/puddlestuff/tagsources/__init__.py
+++ b/source/puddlestuff/tagsources/__init__.py
@@ -27,12 +27,14 @@ class WebServiceError(EnvironmentError):
 
 
 class RetrievalError(WebServiceError):
+
     def __init__(self, msg, code=0):
         WebServiceError.__init__(self, msg)
         self.code = code
 
 
 class SubmissionError(WebServiceError):
+
     def __init__(self, msg, code=0):
         WebServiceError.__init__(self, msg)
         self.code = code
@@ -56,19 +58,12 @@ useragent = "puddletag/" + version_string
 
 def get_encoding(page, decode=False, default=None):
     encoding = None
-    match = re.search('<\?xml(.+)\?>', page)
+    match = re.search(b'<\?xml(.+)\?>', page)
     if match:
         enc = re.search('''encoding(?:\s*)=(?:\s*)["'](.+?)['"]''',
                         match.group(), re.I)
         if enc:
             encoding = enc.groups()[0]
-
-    if not encoding:
-        parser = MetaProcessor()
-        try:
-            parser.feed(page)
-        except FoundEncoding as e:
-            encoding = e.encoding.strip()
 
     if not encoding and default:
         encoding = default
@@ -217,6 +212,7 @@ def write_log(text):
 
 
 class MetaProcessor(HTMLParser):
+
     def reset(self):
         self.pieces = []
         self.encoding = None

--- a/source/requirements.txt
+++ b/source/requirements.txt
@@ -7,3 +7,4 @@ pyqt5==5.15
 configobj==5.0
 mutagen==1.45
 pyparsing==2.4.7
+lxml==4.7.1


### PR DESCRIPTION
This method leans on the html.parser module and that by specification only accepts strings:

https://docs.python.org/3/library/html.parser.html#html.parser.HTMLParser.feed

It cannot therefore be sensibly used to divine the encoding of a byte-string and this whole block of code is  redundant. Likely a carry over from the Python 2 to 3 conversion.

Moreover I can find no reference in nay documentation to a FoundEncoding exception and no idea where that is implemented but certainly not by html.parser.