### PR TITLE
Fix tagsources get_encoding

### DIFF
--- a/source/puddlestuff/tagsources/__init__.py
+++ b/source/puddlestuff/tagsources/__init__.py
@@ -27,12 +27,14 @@ class WebServiceError(EnvironmentError):
 
 
 class RetrievalError(WebServiceError):
+
     def __init__(self, msg, code=0):
         WebServiceError.__init__(self, msg)
         self.code = code
 
 
 class SubmissionError(WebServiceError):
+
     def __init__(self, msg, code=0):
         WebServiceError.__init__(self, msg)
         self.code = code
@@ -56,19 +58,12 @@ useragent = "puddletag/" + version_string
 
 def get_encoding(page, decode=False, default=None):
     encoding = None
-    match = re.search('<\?xml(.+)\?>', page)
+    match = re.search(b'<\?xml(.+)\?>', page)
     if match:
         enc = re.search('''encoding(?:\s*)=(?:\s*)["'](.+?)['"]''',
                         match.group(), re.I)
         if enc:
             encoding = enc.groups()[0]
-
-    if not encoding:
-        parser = MetaProcessor()
-        try:
-            parser.feed(page)
-        except FoundEncoding as e:
-            encoding = e.encoding.strip()
 
     if not encoding and default:
         encoding = default
@@ -217,6 +212,7 @@ def write_log(text):
 
 
 class MetaProcessor(HTMLParser):
+
     def reset(self):
         self.pieces = []
         self.encoding = None


### PR DESCRIPTION
This method leans on the html.parser module and that by specification only accepts strings:

https://docs.python.org/3/library/html.parser.html#html.parser.HTMLParser.feed

It cannot therefore be sensibly used to divine the encoding of a byte-string and this whole block of code is  redundant. Likely a carry over from the Python 2 to 3 conversion.

Moreover I can find no reference in nay documentation to a FoundEncoding exception and no idea where that is implemented but certainly not by html.parser.