### PR TITLE
The AllMusic tagsource was broken

### DIFF
--- a/puddlestuff/tagsources/amg.py
+++ b/puddlestuff/tagsources/amg.py
@@ -177,9 +177,8 @@ def parse_albumpage(page, artist=None, album=None):
 
     album_soup = parse_html.SoupWrapper(parse_html.parse(page))
 
-    artist = album_soup.find('div', {'class': 'album-artist'})
-    album = album_soup.find('div', {'class': 'album-title'})
-
+    album = album_soup.find('h1', {'class': 'album-title'})
+    artist = album_soup.find('h2', {'class': 'album-artist'})
     release_title = album_soup.find('h3', 'release-title')
 
     if release_title:
@@ -494,9 +493,8 @@ def parse_tracks(content, album_info):
 def retrieve_album(url, coverurl=None, id_field=ALBUM_ID):
     write_log('Opening Album Page - %s' % url)
     album_page, code = urlopen(url, False, True)
-    if album_page.find("featured new releases") >= 0:
+    if album_page.find(b"featured new releases") >= 0:
         raise OldURLError("Old AMG URL used.")
-    album_page = get_encoding(album_page, True, 'utf8')[1]
 
     info, tracks = parse_albumpage(album_page)
     info['#albumurl'] = url

--- a/puddlestuff/tagsources/parse_html.py
+++ b/puddlestuff/tagsources/parse_html.py
@@ -1,7 +1,6 @@
 # this module is a hack to overcome BeautifulSoup's tendency to fall on script tags contents
 # while we're at it, we also wrap url fetching.
 
-
 import re
 import urllib.error
 import urllib.parse
@@ -22,6 +21,7 @@ def classify(seq, key_func):
 
 
 class SoupWrapper(object):
+
     def __init__(self, element, source=None):
         self.element = element
         self.source = source
@@ -39,7 +39,9 @@ class SoupWrapper(object):
         regular_items = query_items.get(True, [])
         re_items = query_items.get(False, [])
         xpath_query = " and ".join(
-            "@%s='%s'" % (key, value) for key, value in regular_items
+            "contains(concat(' ',normalize-space(@class),' '),' %s ')" % value if key == "class"
+            else "@%s='%s'" % (key, value)
+            for key, value in regular_items
         )
         if xpath_query:
             xpath_query = "[%s]" % xpath_query


### PR DESCRIPTION
The format of the AllMusic page has clearly changed a little since it was written:

- album  and artist are now in h1 and h2 tags not in div tags
- the class of the sidebar album container is no longer "album-contain" but "album-contain gallery-launch". For which the HTML parser needed a patch to support CSS class matching a la:

https://tanzu.vmware.com/content/blog/xpath-css-class-matching

- A clear bug remained in which album_page was overwrritten by an encoding
- Another bug existed in which a string was sought (.find) in a byte-string.