### PR TITLE
Make tagsource definition files runnable (again)

### DIFF
--- a/puddlestuff/tagsources/acoust_id.py
+++ b/puddlestuff/tagsources/acoust_id.py
@@ -17,14 +17,14 @@ try:
 except ImportError:
     from . import _acoustid as acoustid
 
-from .. import audioinfo
+from puddlestuff import audioinfo
 
-from ..audioinfo import stringtags
-from ..constants import SPINBOX, TEXT
-from ..tagsources import set_status, write_log, SubmissionError
-from ..tagsources.musicbrainz import retrieve_album
-from ..translations import translate
-from ..util import escape_html, isempty, to_string
+from puddlestuff.audioinfo import stringtags
+from puddlestuff.constants import SPINBOX, TEXT
+from puddlestuff.tagsources import set_status, write_log, SubmissionError
+from puddlestuff.tagsources.musicbrainz import retrieve_album
+from puddlestuff.translations import translate
+from puddlestuff.util import escape_html, isempty, to_string
 
 CALCULATE_MSG = translate('AcoustID', "Calculating ID")
 RETRIEVE_MSG = translate('AcoustID', "Retrieving AcoustID data: %1 of %2.")
@@ -235,6 +235,7 @@ def retrieve_album_info(album, tracks):
 
 
 def which(program):
+
     # http://stackoverflow.com/questions/377017/test-if-executable-exists-in-python
     def is_exe(fpath):
         return os.path.isfile(fpath) and os.access(fpath, os.X_OK)

--- a/puddlestuff/tagsources/amazon.py
+++ b/puddlestuff/tagsources/amazon.py
@@ -16,11 +16,11 @@ import urllib.request
 
 from xml.dom import minidom
 
-from ..audioinfo import DATA
-from ..constants import CHECKBOX, COMBO, TEXT
-from ..tagsources import (write_log, RetrievalError,
+from puddlestuff.audioinfo import DATA
+from puddlestuff.constants import CHECKBOX, COMBO, TEXT
+from puddlestuff.tagsources import (write_log, RetrievalError,
                           urlopen, parse_searchstring)
-from ..util import translate
+from puddlestuff.util import translate
 
 default_access_key = base64.b64decode('QUtJQUozS0JZUlVZUU41UFZRR0E=')
 default_secret_key = base64.b64decode('dmh6Q0ZaSEF6N0VvMmN5REt3STVnS1liU3ZFTCtSckx3c0tmanZEdA==')
@@ -67,7 +67,7 @@ def create_aws_url(aws_access_key_id, secret, query_dictionary):
 
     try:
         hm = hmac.new(secret, "GET\nwebservices.amazon.com\n/onca/xml\n" \
-                      + query, hashlib.sha256)
+                      +query, hashlib.sha256)
     except TypeError:
         raise RetrievalError(translate('Amazon',
                                        'Invalid Access or Secret Key'))
@@ -202,8 +202,8 @@ def parse_search_xml(text):
 
 
 def retrieve_album(info, image=MEDIUMIMAGE):
-    """Retrieves album from the information in info. 
-    image must be either one of image_types or None. 
+    """Retrieves album from the information in info.
+    image must be either one of image_types or None.
     If None, no image is retrieved."""
     if isinstance(info, str):
         asin = info
@@ -254,7 +254,6 @@ def search(artist=None, album=None):
     keywords = re.sub('(\s+)', '+', keywords)
     return keyword_search(keywords)
 
-
 # A couple of things you should be aware of.
 # If you're retrieving urls use puddlestuff.tagsources.urlopen instead of the
 # generic urllib functions. When I implement some progress bars, proxies, etc
@@ -270,6 +269,7 @@ def search(artist=None, album=None):
 # MIMETYPE: either 'image/jpg' or 'image/png'
 # DESCRIPTION: the image's description
 # IMAGETYPE: Index of the element corresponding to audioinfo.IMAGETYPES
+
 
 # The only thing required is just a Tag Source object,
 # which'll be the interface to puddletag.
@@ -325,10 +325,10 @@ class Amazon(object):
         # 2. The control type, either TEXT, COMBO or CHECKBOX
         # 3. For TEXT this argument is the default text. It's not required.
         #   For COMBO, the default argument is a list containing a list
-        #   of strings as the first item. 
+        #   of strings as the first item.
         #   And the default index as the second item. eg.
         #   [['text1', 'text2'], 1]
-        #   Checkboxes can either be checked or not so 
+        #   Checkboxes can either be checked or not so
         #   default arguments must either True or False.
 
         # When the user has finished editing, the Object.applyPrefs will be

--- a/puddlestuff/tagsources/amg.py
+++ b/puddlestuff/tagsources/amg.py
@@ -8,10 +8,10 @@ import urllib.parse
 import urllib.request
 
 from . import parse_html
-from ..audioinfo import isempty, CaselessDict
-from ..constants import CHECKBOX
-from ..puddleobjects import ratio
-from ..tagsources import (write_log, set_status, RetrievalError,
+from puddlestuff.audioinfo import isempty, CaselessDict
+from puddlestuff.constants import CHECKBOX
+from puddlestuff.puddleobjects import ratio
+from puddlestuff.tagsources import (write_log, set_status, RetrievalError,
                           urlopen, parse_searchstring, retrieve_cover, get_encoding, iri_to_uri)
 
 

--- a/puddlestuff/tagsources/discogs.py
+++ b/puddlestuff/tagsources/discogs.py
@@ -9,11 +9,11 @@ import urllib.request
 from copy import deepcopy
 from io import StringIO
 
-from ..audioinfo import DATA, isempty
-from ..constants import CHECKBOX, COMBO, TEXT
-from ..tagsources import (
+from puddlestuff.audioinfo import DATA, isempty
+from puddlestuff.constants import CHECKBOX, COMBO, TEXT
+from puddlestuff.tagsources import (
     find_id, write_log, RetrievalError, iri_to_uri, get_useragent)
-from ..util import translate
+from puddlestuff.util import translate
 
 R_ID_DEFAULT = 'discogs_id'
 R_ID = R_ID_DEFAULT

--- a/puddlestuff/tagsources/example.py
+++ b/puddlestuff/tagsources/example.py
@@ -18,8 +18,8 @@
 
 import os
 
-from ..constants import TAGSOURCE, HOMEDIR, TEXT
-from ..puddleobjects import gettags, getfiles, PuddleConfig
+from puddlestuff.constants import TAGSOURCE, HOMEDIR, TEXT
+from puddlestuff.puddleobjects import gettags, getfiles, PuddleConfig
 
 # print 'example2'
 
@@ -62,7 +62,7 @@ class Example(object):
         ret = []
         matches = {}
         # set_status('Searching %s - %s' % (artist, albums[0]))
-        ##write_log('Retrieving %s %s' % (artist, albums[0]))
+        # #write_log('Retrieving %s %s' % (artist, albums[0]))
         albumtuple = [z.split(' - ', 1) for z in self._dirs
                       if z.startswith(artist) and ' - ' in z]
         albumtuple = [(i, z) for i, z in albumtuple]

--- a/puddlestuff/tagsources/freedb.py
+++ b/puddlestuff/tagsources/freedb.py
@@ -1,12 +1,13 @@
 from . import CDDB
 
 CDDB.proto = 6  # utf8 instead of latin1
-from ..util import to_string
 from collections import defaultdict
-from ..tagsources import RetrievalError
-from .. import version_string
-from .. import audioinfo
-from ..util import translate
+
+from puddlestuff import version_string
+from puddlestuff import audioinfo
+from puddlestuff.util import to_string
+from puddlestuff.tagsources import RetrievalError
+from puddlestuff.util import translate
 import time
 
 CLIENTINFO = {'client_name': "puddletag",
@@ -17,6 +18,7 @@ def sumdigits(n): return sum(map(int, str(n)))
 
 
 def sort_func(key, default):
+
     def func(audio):
         track = to_string(audio.get(key, [default]))
         try:

--- a/puddlestuff/tagsources/mp3tag/__init__.py
+++ b/puddlestuff/tagsources/mp3tag/__init__.py
@@ -9,13 +9,16 @@ from pyparsing import (nums, printables, Combine, Optional,
                        QuotedString, Word, ZeroOrMore)
 
 from .funcs import FUNCTIONS
-from .. import (urlopen, get_encoding,
-                write_log, retrieve_cover, set_status)
-from ...audioinfo.util import CaselessDict
-from ...constants import CHECKBOX
-from ...functions import format_value
-from ...translations import translate
-from ...util import convert_dict as _convert_dict
+
+from puddlestuff.tagsources import (urlopen, get_encoding,
+                                    write_log, retrieve_cover,
+                                    set_status)
+
+from puddlestuff.audioinfo.util import CaselessDict
+from puddlestuff.constants import CHECKBOX
+from puddlestuff.functions import format_value
+from puddlestuff.translations import translate
+from puddlestuff.util import convert_dict as _convert_dict
 
 
 class ParseError(Exception): pass
@@ -190,6 +193,7 @@ def parse_search_page(indexformat, page, search_source, url=None):
 
 
 class Cursor(object):
+
     def __init__(self, text, source_lines):
         self.text = text
         self.all_lines = [z + ' ' for z in text.split('\n')] + [' ']
@@ -312,6 +316,7 @@ class Cursor(object):
 
 
 class Mp3TagSource(object):
+
     def __init__(self, idents, search_source, album_source):
 
         self._get_cover = True
@@ -432,20 +437,20 @@ if __name__ == '__main__':
     # import puddlestuff.tagsources
     # encoding, text = puddlestuff.tagsources.get_encoding(text, True, 'utf8')
 
-    ##pdb.set_trace()
+    # #pdb.set_trace()
     # idents, search, album = open_script(sys.argv[2])
     # value = parse_search_page(idents['indexformat'], text, search)
 
-    ##value = parse_album_page(text, album, 'url')
+    # #value = parse_album_page(text, album, 'url')
     # print value
     # pdb.set_trace()
     # print convert_value(value)
-    ##source = find_idents(lines)[1]
+    # #source = find_idents(lines)[1]
 
-    ##print parse_search(idents['indexformat'], search, text)
-    ###text = open('d_album.htm', 'r').read()
-    ##c = Cursor(text.decode('utf8', 'replace'), source)
-    ##c.parse_page()
-    ###print c.cache
-    ###print c.tracks[0]
-    ##print '\n'.join('%s: %s' % z for z in c.album.items())
+    # #print parse_search(idents['indexformat'], search, text)
+    # ##text = open('d_album.htm', 'r').read()
+    # #c = Cursor(text.decode('utf8', 'replace'), source)
+    # #c.parse_page()
+    # ##print c.cache
+    # ##print c.tracks[0]
+    # #print '\n'.join('%s: %s' % z for z in c.album.items())

--- a/puddlestuff/tagsources/mp3tag/funcs.py
+++ b/puddlestuff/tagsources/mp3tag/funcs.py
@@ -4,8 +4,8 @@ import re
 
 from html.parser import HTMLParser
 
-from ...functions import replace_regex
-from ...audioinfo import CaselessDict
+from puddlestuff.functions import replace_regex
+from puddlestuff.audioinfo import CaselessDict
 
 conditionals = set(['if', 'ifnot'])
 
@@ -401,6 +401,7 @@ def unspace(cursor):
 
 
 class TagProcessor(HTMLParser):
+
     def reset(self):
         self.pieces = []
         HTMLParser.reset(self)

--- a/puddlestuff/tagsources/mp3tag/parse_debug.py
+++ b/puddlestuff/tagsources/mp3tag/parse_debug.py
@@ -1,7 +1,7 @@
 import codecs
 import pdb
 
-from ..mp3tag import open_script, Cursor
+from . import open_script, Cursor
 
 dbg_skip = ['ifnot', 'do', 'while']
 src_skip = ['endif', 'do', 'while', 'ifnot', 'else']

--- a/puddlestuff/tagsources/musicbrainz.py
+++ b/puddlestuff/tagsources/musicbrainz.py
@@ -11,11 +11,11 @@ from xml.sax.saxutils import escape, quoteattr
 from html.parser import HTMLParser
 from xml.dom import minidom, Node
 
-from ..audioinfo import IMAGETYPES, get_mime, strlength
-from ..constants import CHECKBOX, COMBO
-from ..tagsources import (find_id, write_log, RetrievalError,
+from puddlestuff.audioinfo import IMAGETYPES, get_mime, strlength
+from puddlestuff.constants import CHECKBOX, COMBO
+from puddlestuff.tagsources import (find_id, write_log, RetrievalError,
                           urlopen, parse_searchstring)
-from ..util import isempty, translate
+from puddlestuff.util import isempty, translate
 
 SERVER = 'http://musicbrainz.org/ws/2/'
 
@@ -471,6 +471,7 @@ def to_list(v, arg=None):
 
 
 class XMLEscaper(HTMLParser):
+
     def reset(self):
         HTMLParser.reset(self)
         self._xml = []


### PR DESCRIPTION
I can now run one from the puddletag source dir with:

`PYTHONPATH=. python puddlestuff/tagsources/discogs.py`

which was clearly the intent at some point given they all have an:

`if __name__ == '__main__':`

block. But they could not run because of relative package imports. These have now been made explicit. Which is safe enough and and I see little reason to keep them relative while breaking the ability to debug tagsources outside of the threaded context of the UI.