### PR TITLE
An attempt to document the tagsource interface

### DIFF
--- a/puddlestuff/tagsources/TagSource.py
+++ b/puddlestuff/tagsources/TagSource.py
@@ -41,6 +41,9 @@ class TagSource():
         Called to retrieve release information when expanding a release in the Tag Sources Tree view
 
         :param release: A dict containing information about an album release
+        :return: a 2-tuple containing
+                    a dict of album release tags/fields and their values, and
+                    a list of dicts containing album track tags/fields and their values
         '''
         raise UnimplementedMethod("TagsSource.retrieve")
 
@@ -49,6 +52,7 @@ class TagSource():
         Called when Search button is clicked, if the Search box contains some text
 
         :param text: The text in the Search box
+        :return: A list of 2-tuples as described in retrieve() above
         '''
         raise UnimplementedMethod("TagsSource.keyword_search")
 
@@ -65,8 +69,9 @@ class TagSource():
         :param files: Provided only if self.group_by is defined. In which case it is the contents of the named group.
                       This will be a dict level for each remaining group_by tag, with a list of files at the bottom
                       (a ModelTag instances - see puddlestuff.tagmodel.model_tag.ModelTag).
+        :return: A list of 2-tuples as described in retrieve() above
         '''
-        raise UnimplementedMethod("TagsSource.keyword_search")
+        raise UnimplementedMethod("TagsSource.search")
 
     def submit(self, files):
         '''
@@ -81,5 +86,6 @@ class TagSource():
 
         :param files: a list of selected audio files as ModelTag instances.
                         (see puddlestuff.tagmodel.model_tag.ModelTag)
+        :return: Nothing. No result is checked.
         '''
         raise UnimplementedMethod("TagsSource.submit")

--- a/puddlestuff/tagsources/TagSource.py
+++ b/puddlestuff/tagsources/TagSource.py
@@ -1,0 +1,85 @@
+# An interface specification for Tag Sources
+#
+# A Tag Source should define a class that derives from TagSOurce, and sets
+# a module attribue "info" to an instance of that class in order to interface
+# with puddletag
+from puddlestuff.util import translate
+from puddlestuff.constants import TEXT, CHECKBOX, SPINBOX, TAGLIST, COMBO
+
+
+class UnimplementedMethod(Exception):
+    pass
+
+
+class TagSource():
+    # A name for the tag source. Keep it short.
+    name = "Generic Tag Source"
+
+    # A list of tags to group album releases by.
+    group_by = ["album", "artist"]
+
+    # A ToolTip that displays when hovering above the Search box
+    # Set to None to disable ToolTip
+    tooltip = translate("Group", "HTML Tooltip Content")
+
+    # A Set of preferences to display on the preference dialog box
+    # Set to None to disable Preferences for this Tag Source
+    preferences = [
+                    [translate("Discogs", 'A Text Option'), TEXT, "Default Value"],
+                    [translate("Discogs", 'A Checkbox Option'), CHECKBOX, True],  # Default value, True or False
+                    [translate("Discogs", 'A Spinbox Integer'), SPINBOX, [0, 100, 50]],  # Minimum, Maximum, Default values
+                    [translate("Discogs", 'A Tag List'), TAGLIST, []],  # Undocumented, no exemplar and unimplemented
+                    [translate("Discogs", 'A Combobox Option'), COMBO,
+                        [[translate("Discogs", 'Option 1'), translate("Discogs", 'Option 2')], 1]]  # List of option texts and default selection
+                ]
+
+    # Note the TAGLIST preference type is currently not implemented.
+    # See: puddlestuff.webdb.SimpleDialog
+
+    def retrieve(self, release):
+        '''
+        Called to retrieve release information when expanding a release in the Tag Sources Tree view
+
+        :param release: A dict containing information about an album release
+        '''
+        raise UnimplementedMethod("TagsSource.retrieve")
+
+    def keyword_search(self, text):
+        '''
+        Called when Search button is clicked, if the Search box contains some text
+
+        :param text: The text in the Search box
+        '''
+        raise UnimplementedMethod("TagsSource.keyword_search")
+
+    def search(self, files_or_group, files=None):
+        '''
+        Called when Search button is clicked, if the Search box is empty
+
+        :param files_or_group: if self.group_by is Falsey, a list of selected audio files as ModelTag instances.
+                                (see puddlestuff.tagmodel.model_tag.ModelTag)
+                               if if self.group_by is a list of attributes then the value of the first group_by tag.
+                               For example if the first group_by tag is "artist" then this will be name of an artist
+                               to search for.
+
+        :param files: Provided only if self.group_by is defined. In which case it is the contents of the named group.
+                      This will be a dict level for each remaining group_by tag, with a list of files at the bottom
+                      (a ModelTag instances - see puddlestuff.tagmodel.model_tag.ModelTag).
+        '''
+        raise UnimplementedMethod("TagsSource.keyword_search")
+
+    def submit(self, files):
+        '''
+        If defined the a Submit button is presented, and when clicked calls here
+        for submitting data from the list of suplied files (to the remote web database)
+
+        If not implementing this do so explicitly with:
+
+            delattr(self, "submit")
+
+        in the Tag Sources __init__() method.
+
+        :param files: a list of selected audio files as ModelTag instances.
+                        (see puddlestuff.tagmodel.model_tag.ModelTag)
+        '''
+        raise UnimplementedMethod("TagsSource.submit")


### PR DESCRIPTION
And provide a class from which tag sources should derive.

Assembling this raises some interesting questions about puddletags interface to tagsources and I suspect it can be improved significantly

Two areas of grave concern:

1. The `search()` method has a very bizarre interface that depends upon the definition of group_by. This should be standardised. Easy to do by fixing `webdb.py`.

2. The group_by attribute seems flexible but there are rather heavily hardcoded assumptions that it's first entry is "album" to my mind,  and the retrieve() method is always receiving the value of the tag that is the first entry in group_by. 

And areas of mild concern arise:

1. `TAGLIST` is unimplemented and no clue is easily found what was envisioned here.
2. `search` and `keyword_search` should really be one function I see no reason to separated these. A simple signature of a `search(`)` method is not hard to devise that can serve both needs, for example:

`def search(text='', files=None, album=None):`

where the arguments are all optional and can be used in a named fashion. And so search is always provided with contents of the search box and list of selected files and optionally an album release name and the tags source implementer can do what they wish with that.

Something clearly missing from this spec still is a tabling of expectations for the contents of the `release` dict and a specification of the return values (I'll push that next) and in particular the minimal contents and possible contents of the returned `info` dict that search. I'm working on that, but as ever, and tips and guidance are appreciated.

I feel a clear and clean API here is a major asset if we hope for community contributions in the form of tag sources or getting those mp3tag sources to work etc.