### PR TITLE
Simplify/rationalise rate limiting of requests

### DIFF
--- a/puddlestuff/tagsources/discogs.py
+++ b/puddlestuff/tagsources/discogs.py
@@ -61,13 +61,8 @@ INVALID_KEYS = [
     'extraartists', 'images', 'videos', 'master_id', 'labels', 'companies',
     'series', 'released_formatted', 'identifiers', 'sub_tracks']
 
-
-class LastTime(object):
-    pass
-
-
-__lasttime = LastTime()
-__lasttime.time = time.time()
+__minimum_request_separation = 1  # second - no more than one request sent to discogs in this time frame
+__reference_time = 0  # A reference time. The initial value ensure first request goes ahead
 
 
 def convert_dict(d, keys=None):
@@ -306,9 +301,9 @@ def urlopen(url):
     request.add_header('Accept-Encoding', 'gzip')
     request.add_header('User-Agent', get_useragent())
 
-    if time.time() - __lasttime.time < 1:
-        time.sleep(1)
-    __lasttime.time = time.time()
+    while (time.time() - __reference_time) < __minimum_request_separation:
+        time.sleep(__minimum_request_separation)
+    __reference_time = time.time()
 
     try:
         data = urllib.request.urlopen(request).read()


### PR DESCRIPTION
This one puzzles me deeply. How and when did who justify creating a class with an attribute to store a single time value to drive rate limiting? 

The idea of rate limiting requests to no more than one per second is sound. But while great effort was given to an unneeded class, a configurable rate was not. That is now available.

This is another tiny PR to test PR waters a bit. It's a trivial change with no functional impact, just a style question. 