### PR TITLE
Removed unused functions

### DIFF
--- a/puddlestuff/tagsources/discogs.py
+++ b/puddlestuff/tagsources/discogs.py
@@ -98,16 +98,6 @@ def check_values(d):
     return ret
 
 
-def keyword_search(keywords):
-    write_log(
-        translate("Discogs",
-                  'Retrieving search results for keywords: %s') % keywords)
-    keywords = re.sub('(\s+)', '+', keywords)
-    url = SEARCH_URL % keywords
-    text = urlopen(url)
-    return parse_search_json(json.loads(text))
-
-
 def parse_tracklist(tlist):
     tracks = []
     for t in tlist:
@@ -190,42 +180,6 @@ def parse_album_json(data):
     return info, parse_tracklist(data['tracklist'])
 
 
-def parse_search_json(data):
-    """Parses the xml retrieved after entering a search query. Returns a
-    list of the albums found.
-    """
-
-    results = data.get('results', []) + data.get('exactresults', [])
-
-    if not results:
-        return []
-
-    albums = []
-
-    for result in results:
-        info = result.copy()
-        try:
-            artist, album = result['title'].split(' - ')
-        except ValueError:
-            album = result['title']
-            artist = ''
-
-        info = convert_dict(info, ALBUM_KEYS)
-
-        info['artist'] = artist
-        info['album'] = album
-
-        info['discogs_id'] = info['#r_id']
-
-        info['#extrainfo'] = (
-            translate('Discogs', '%s at Discogs.com') % info['album'],
-            SITE_URL + info['discogs_uri'])
-
-        albums.append(check_values(info))
-
-    return albums
-
-
 def retrieve_album(info, image=LARGEIMAGE, rls_type=None):
     """Retrieves album from the information in info.
     image must be either one of image_types or None.
@@ -288,16 +242,6 @@ def retrieve_album(info, image=LARGEIMAGE, rls_type=None):
     except KeyError:
         pass
     return info, ret[1]
-
-
-def search(artist=None, album=None):
-    if artist and album:
-        keywords = ' '.join([artist, album])
-    elif artist:
-        keywords = artist
-    else:
-        keywords = album
-    return keyword_search(keywords)
 
 
 def urlopen(url):

--- a/puddlestuff/tagsources/discogs.py
+++ b/puddlestuff/tagsources/discogs.py
@@ -174,7 +174,7 @@ def parse_album_json(data):
     return info, parse_tracklist(data['tracklist'])
 
   
-  def retrieve_album(info, image=LARGEIMAGE, rls_type=None):
+def retrieve_album(info, image=LARGEIMAGE, rls_type=None):
     """Retrieves album from the information in info.
     image must be either one of image_types or None.
     If None, no image is retrieved."""


### PR DESCRIPTION
After reviewing the API for tagsources it becomes clear that the only thing imported from any is the `info` attribute and that leaves three, seemingly legacy functions, polluting the discogs tagsource code. 

They have been removed, and a runtime test performed to rule out any oversights.

Sorry to be flooding you with PRs. But I am keeping them small, and as independent as possible for very simple review and merge. 