### PR TITLE
Explicit message for UnicodeError

### DIFF
--- a/puddlestuff/puddletag.py
+++ b/puddlestuff/puddletag.py
@@ -540,6 +540,10 @@ class MainWin(QMainWindow):
             QMessageBox.information(self._table,
                                     translate("Defaults", 'Error'),
                                     translate("Playlist", 'An error occured while reading <b>%1</b> (%2)').arg(filename).arg(e.strerror))
+        except (UnicodeError) as e:
+            QMessageBox.information(self._table,
+                                    translate("Defaults", 'Error'),
+                                    translate("Playlist", 'The playlist is not encoded in UTF-8'))
         except Exception as e:
             QMessageBox.information(self._table, translate("Defaults", 'Error'),
                                     translate("Playlist", 'An error occured while reading <b>%1</b> (%2)').arg(filename).arg(str(e)))


### PR DESCRIPTION
The default message is not 100% obvious that UTF8 encoding is required. This message is hopefully more verbose.

Previous pull request #660 tried to implement compatibility to latin9, but this was very obscure and does not help other encodings with the same issues.