### PR TITLE
Fix scrolling

### DIFF
--- a/puddlestuff/actiondlg.py
+++ b/puddlestuff/actiondlg.py
@@ -150,7 +150,7 @@ class ScrollLabel(QScrollArea):
     def wheelEvent(self, e):
         h = self.horizontalScrollBar()
         if h.isVisible():
-            numsteps = e.angleDelta().y() / 5
+            numsteps = e.angleDelta().y() // 5
             h.setValue(h.value() - numsteps)
             e.accept()
         else:

--- a/puddlestuff/mainwin/storedtags.py
+++ b/puddlestuff/mainwin/storedtags.py
@@ -136,7 +136,7 @@ class StoredTags(QScrollArea):
     def wheelEvent(self, e):
         h = self.horizontalScrollBar()
         if not self.verticalScrollBar().isVisible() and h.isVisible():
-            numsteps = e.angleDelta().y() / 5
+            numsteps = e.angleDelta().y() // 5
             h.setValue(h.value() - numsteps)
             e.accept()
         else:

--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -2479,7 +2479,7 @@ class TagTable(QTableView):
     def wheelEvent(self, e):
         h = self.horizontalScrollBar()
         if not self.verticalScrollBar().isVisible() and h.isVisible():
-            numsteps = e.angleDelta().y() / 5
+            numsteps = e.angleDelta().y() // 5
             h.setValue(h.value() - numsteps)
             e.accept()
         else:


### PR DESCRIPTION
The `setValue` method now expects a int, but the division results in a
float. Since the value and the angleDelta are already integers, just do
a integer division instead.
I was thinking about just using `int()` to convert the float, but I
liked the integer division solution better.

Fixes #662