### PR TITLE
MusicBrainz bugfixes

### DIFF
--- a/puddlestuff/mainwin/storedtags.py
+++ b/puddlestuff/mainwin/storedtags.py
@@ -94,35 +94,36 @@ class StoredTags(QScrollArea):
             # print 'loading', time.time()
             while self._loading:
                 QApplication.processEvents()
-            self._loading = True
-            self._init()
-            if not tags:
+            try:
+                self._loading = True
+                self._init()
+                if not tags:
+                    return
+
+                grid = self._grid
+
+                offset = 1
+                for title, values in tags:
+                    if not values:
+                        continue
+                    t_label = QLabel(title)
+                    t_label.setFont(self._boldfont)
+                    grid.addWidget(t_label, offset - 1, 0)
+                    for row, (tag, value) in enumerate(values):
+                        field = QLabel('%s:' % tag)
+                        field.setAlignment(Qt.AlignTop | Qt.AlignLeft)
+                        grid.addWidget(field, row + offset, 0)
+                        vlabel = QLabel(value)
+                        grid.addWidget(vlabel, row + offset, 1)
+                    grid.setRowMinimumHeight(grid.rowCount(),
+                                             vlabel.sizeHint().height())
+                    offset += grid.rowCount() + 1
+                vbox = QVBoxLayout()
+                vbox.addStretch()
+                grid.addLayout(vbox, offset + 1 + offset, 0, -1, -1)
+                grid.setRowStretch(offset + 1, 1)
+            finally:
                 self._loading = False
-                return
-
-            grid = self._grid
-
-            offset = 1
-            for title, values in tags:
-                if not values:
-                    continue
-                t_label = QLabel(title)
-                t_label.setFont(self._boldfont)
-                grid.addWidget(t_label, offset - 1, 0)
-                for row, (tag, value) in enumerate(values):
-                    field = QLabel('%s:' % tag)
-                    field.setAlignment(Qt.AlignTop | Qt.AlignLeft)
-                    grid.addWidget(field, row + offset, 0)
-                    vlabel = QLabel(value)
-                    grid.addWidget(vlabel, row + offset, 1)
-                grid.setRowMinimumHeight(grid.rowCount(),
-                                         vlabel.sizeHint().height())
-                offset += grid.rowCount() + 1
-            vbox = QVBoxLayout()
-            vbox.addStretch()
-            grid.addLayout(vbox, offset + 1 + offset, 0, -1, -1)
-            grid.setRowStretch(offset + 1, 1)
-            self._loading = False
 
         thread = PuddleThread(retrieve_tag, self)
         thread.threadfinished.connect(_load)

--- a/puddlestuff/tagsources/musicbrainz.py
+++ b/puddlestuff/tagsources/musicbrainz.py
@@ -282,8 +282,9 @@ def parse_release(node):
     info = convert_dict(info, ALBUM_KEYS)
     info['#album_id'] = info['mbrainz_album_id']
 
-    if 'count' in info:
-        del (info['count'])
+    for k in ['count', 'track-list']:
+        if k in info:
+            del info[k]
 
     if 'disambiguation' in info:
         info['album'] = "%s (%s)" % (info['album'], info['disambiguation'])


### PR DESCRIPTION
## Fix UFID in ID3
    
Through some python 2 migration confusion (str/unicode vs. bytes/str)
the handling of the ID3 UFID frames broke. As per the [spec](https://id3.org/id3v2.4.0-frames) (chapter 4.1), these
frames have a binary content (so not necessarily a string). Mutagen
passes the content correctly as `bytes`, but puddletag internally
handles it as a utf8-encoded string, so the id3 wrapper has to handle
the conversions in both directions. If the content should be non-utf8,
it will simply be ignored. This behaviour is not ideal, but I couldn't
think of a better one right now.
With the conversion working again, the stored tags window only gets
strings again, and puddletag does not crash.

This partially reverts commit c0504240a2b947da91c1e6549ba48040238d8460.

Fixes #590
Fixes #565
Fixes #595

I haven't pinned down the exact versions, but some versions of the
dependencies (like pyqt) behave differently. Instead of crashing the
whole process, they only fail a thread and the process continues to run.
This leaves it in a somewhat undefined state and results in what is
described in #615, where all tags beyond the offending UFID are cut off
in the stored tags. With the UFID fixed, all tags are now displayed.

Fixes #615


## Fix hanging thread
    
Even though this issue does not occur anymore with the UFID fix, it is
still worth fixing. The issue seems to be that the `_loading` flag is
not reset when an error occurs in the `_load(tags)` method, and through
that locking the another thread in the `QApplication.processEvents()`
loop. To always reset that flag, wrap the set und unset of it in a
try/finally block.

Fixes #568
Fixes #647


## MusicBrainz: ignore track-list

Sometimes (but not always) a release (which can be a album or a single
or sumsuch) from musicbrainz contains a track-list, which is a list
with some basic info about all the tracks. When writing from the tag
source to files, this release info gets merged with track infos to form
the actual tags to be written. On this way the track-list also gets
passed on and mapped into the files as `track-list` tags with bogus
values.

```
  ...
  'title': 'Stuck on the Puzzle',
  'track': '5',
  'track-list': { 'count': '6',
                  'offset': '0',
                  'track':  [ { 'id': '9d9d60dc-2e9f-3852-954e-7651bc6594d3',
                                'length': '53000',
                                'number': '1',
                                ...
```

The track info from the release is a subset of the actual track info,
and it is never used; so we can just ignore/remove it and be done.

Fixes #659