### PR TITLE
Use valid fallback lang for id3 uslt

### DIFF
--- a/puddlestuff/audioinfo/id3.py
+++ b/puddlestuff/audioinfo/id3.py
@@ -637,7 +637,7 @@ def set_uslt(f, value):
             continue
         len_l = len(lyrics)
         if len_l == 1:
-            lang = 'XXX'
+            lang = ''
             desc = ''
             text = lyrics[0]
         elif len_l == 2:
@@ -654,8 +654,8 @@ def set_uslt(f, value):
         else:
             continue
 
-        if not lang:
-            lang = 'XXX'
+        if not lang or len(lang) is not 3:
+            lang = 'und'
         frames.append(id3.USLT(encoding, lang, desc, text))
 
     if not frames:


### PR DESCRIPTION
The language of a USLT frame has to be a valid ISO 639-2 language code.
Instead of falling back to `XXX` which is invalid, use the proper `und`
(undefined).
Because of the way puddletag handles multi-value frames as a single
`|`-sepeared string, it is hard to do a proper validation in the gui.
The language is required for USLT and mutagen will complain harshly
with a crash when it is missing or too short (less than 3 chars). So
extend the fallback to also cover that case.