### PR TITLE
Preserve column sizes

### DIFF
--- a/puddlestuff/plugins/view_all_fields/__init__.py
+++ b/puddlestuff/plugins/view_all_fields/__init__.py
@@ -48,7 +48,7 @@ def show_all_fields(fields=None):
     data = [(k, k) for k in fields + sorted(keys, key=natsort_case_key)]
     tb = status['table']
     tb.model().setHeader(data)
-    hd = TableHeader(Qt.Orientation.Horizontal, data)
+    hd = TableHeader(Qt.Orientation.Horizontal)
     tb.setHorizontalHeader(hd)
     hd.show()
 

--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -1302,6 +1302,7 @@ class TableHeader(QHeaderView):
 
     def __init__(self, orientation, parent=None):
         QHeaderView.__init__(self, orientation, parent)
+        self.setVisible(True)
         self.setSectionsClickable(True)
         self.setHighlightSections(True)
         self.setSectionsMovable(True)
@@ -1375,7 +1376,6 @@ class TagTable(QTableView):
         if not headerdata:
             headerdata = []
         header = TableHeader(Qt.Orientation.Horizontal, self)
-        header.setSortIndicatorShown(True)
         self.setSortingEnabled(True)
         self._savedSelection = False
 
@@ -1402,7 +1402,6 @@ class TagTable(QTableView):
         self.setHorizontalScrollMode(QAbstractItemView.ScrollMode.ScrollPerPixel)
 
         model = TagModel(headerdata)
-        header.headerChanged.connect(self.setHeaderTags)
         self.setModel(model)
 
         def emitundo(val):
@@ -2340,9 +2339,6 @@ class TagTable(QTableView):
 
         self.saveSelection()
         hd = TableHeader(Qt.Orientation.Horizontal, self)
-        hd.setSortIndicatorShown(True)
-        hd.setVisible(True)
-        hd.headerChanged.connect(self.setHeaderTags)
         self.setHorizontalHeader(hd)
         self.model().setHeader(tags)
 
@@ -2355,6 +2351,7 @@ class TagTable(QTableView):
     def setHorizontalHeader(self, header):
         header.setModel(self.model())
         QTableView.setHorizontalHeader(self, header)
+        header.headerChanged.connect(self.setHeaderTags)
         header.saveSelection.connect(self.saveSelection)
 
     def writeError(self, text):

--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -1300,9 +1300,8 @@ class TableHeader(QHeaderView):
     saveSelection = pyqtSignal(name='saveSelection')
     headerChanged = pyqtSignal([list, list], name='headerChanged')
 
-    def __init__(self, orientation, tags=None, parent=None):
+    def __init__(self, orientation, parent=None):
         QHeaderView.__init__(self, orientation, parent)
-        if tags is not None: self.tags = tags
         self.setSectionsClickable(True)
         self.setHighlightSections(True)
         self.setSectionsMovable(True)
@@ -1375,7 +1374,7 @@ class TagTable(QTableView):
         self.settingsdialog = ColumnSettings
         if not headerdata:
             headerdata = []
-        header = TableHeader(Qt.Orientation.Horizontal, headerdata, self)
+        header = TableHeader(Qt.Orientation.Horizontal, self)
         header.setSortIndicatorShown(True)
         self.setSortingEnabled(True)
         self._savedSelection = False
@@ -2340,7 +2339,7 @@ class TagTable(QTableView):
     def setHeaderTags(self, tags, hidden=None):
 
         self.saveSelection()
-        hd = TableHeader(Qt.Orientation.Horizontal, tags, self)
+        hd = TableHeader(Qt.Orientation.Horizontal, self)
         hd.setSortIndicatorShown(True)
         hd.setVisible(True)
         hd.headerChanged.connect(self.setHeaderTags)
@@ -2354,6 +2353,7 @@ class TagTable(QTableView):
         self.restoreSelection()
 
     def setHorizontalHeader(self, header):
+        header.setModel(self.model())
         QTableView.setHorizontalHeader(self, header)
         header.saveSelection.connect(self.saveSelection)
 

--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -2338,10 +2338,18 @@ class TagTable(QTableView):
     def setHeaderTags(self, tags, hidden=None):
 
         self.saveSelection()
-        hd = TableHeader(Qt.Orientation.Horizontal, self)
-        self.setHorizontalHeader(hd)
+        old_column_sizes = {val[0]: self.horizontalHeader().sectionSize(idx)
+            for idx,val in enumerate(self.model().headerdata)
+            if self.horizontalHeader().sectionSize(idx) > 0}
+
         self.model().setHeader(tags)
 
+        hd = TableHeader(Qt.Orientation.Horizontal, self)
+        self.setHorizontalHeader(hd)
+        if not self.autoresize:
+            for idx, val in enumerate(self.model().headerdata):
+                if val[0] in old_column_sizes:
+                    hd.resizeSection(idx, old_column_sizes[val[0]])
         if hidden is not None:
             for c in hidden:
                 hd.hideSection(c)


### PR DESCRIPTION
When column layout changes, take a snapshot of the current column
sizes and apply them to the new layout. Columns are matched by their
name/title, so two columns with the same name/title will both get the
same size of the previously rightmost one of them. Hidden columns have
a size of 0, so be sure to ignore them, elsewise un-hiding won't work.
For obvious reasons, this only applies if puddletag is not configured
to autoresize the columns.
This change has a (IMHO nice) side effect: When you switch from
autoresize to not-autoresize, the columns will retain their last
(autoresized) size and can be manually resized from there.

Plus some minor refactoring/cleanup.

Fixes #640 