### PR TITLE
About dialogue improvements

### DIFF
--- a/puddlestuff/__init__.py
+++ b/puddlestuff/__init__.py
@@ -11,11 +11,16 @@ version_string = ".".join(map(str, version))
 
 changeset = None
 
-filedir = dirname(dirname(dirname(__file__)))
-hash_file = os.path.join(filedir, ".git/refs/heads/master")
+filedir = dirname(__file__)
+git_root = os.path.join(filedir, '..')
+hash_file = os.path.join(git_root, '.git', 'HEAD')
 if os.path.exists(hash_file):
     try:
         with open(hash_file) as fo:
             changeset = fo.read().strip()
+        if changeset.startswith("ref: "):
+            hash_file = os.path.join(git_root, '.git', *(changeset[5:].split('/')))
+            with open(hash_file) as fo:
+                changeset = fo.read().strip()
     except (EnvironmentError, AttributeError):
         pass

--- a/puddlestuff/about.py
+++ b/puddlestuff/about.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 import mutagen
-import pyparsing
-from PyQt5.QtCore import PYQT_VERSION_STR, Qt
+from importlib import import_module
+from platform import python_version
+from PyQt5.QtCore import PYQT_VERSION_STR, QT_VERSION_STR, Qt
 from PyQt5.QtGui import QPixmap
 from PyQt5.QtWidgets import QApplication, QDialog, QHBoxLayout, QLabel, QScrollArea, QTabWidget, QVBoxLayout, QWidget
 
@@ -38,10 +39,32 @@ The <b>Oxygen team</b> for the Oxygen icons.
 
 
 def versions():
+    def get_module_version(module_name):
+        try:
+            from importlib.metadata import version
+            return version(module_name)
+        except ModuleNotFoundError:
+            pass
+
+        try:
+            module = import_module(module_name)
+            return getattr(module, '__version__',
+                translate("About", 'unknown version'))
+        except ModuleNotFoundError:
+            return translate("About", 'not installed')
+
     return {
+        'Python': python_version(),
         'PyQt': PYQT_VERSION_STR,
+        'Qt': QT_VERSION_STR,
         'Mutagen': mutagen.version_string,
-        'Pyparsing': pyparsing.__version__,
+        'PyParsing': get_module_version('pyparsing'),
+        'ConfigObj': get_module_version('configobj'),
+        'lxml': get_module_version('lxml'),
+        'pyacoustid': get_module_version('pyacoustid'),
+        'audioread': get_module_version('audioread'),
+        'Levenshtein': get_module_version('Levenshtein'),
+        'Chromaprint': get_module_version('chromaprint'),
     }
 
 

--- a/puddlestuff/about.py
+++ b/puddlestuff/about.py
@@ -37,6 +37,14 @@ The <b>Oxygen team</b> for the Oxygen icons.
 """)
 
 
+def versions():
+    return {
+        'PyQt': PYQT_VERSION_STR,
+        'Mutagen': mutagen.version_string,
+        'Pyparsing': pyparsing.__version__,
+    }
+
+
 class ScrollLabel(QWidget):
     def __init__(self, text, alignment=Qt.AlignmentFlag.AlignCenter, parent=None):
         QWidget.__init__(self, parent)
@@ -62,25 +70,25 @@ class AboutPuddletag(QDialog):
         self.setWindowTitle(translate("About", 'About puddletag'))
         icon = QLabel()
         icon.setPixmap(QPixmap(':/appicon.png').scaled(48, 48))
-        lib_versions = ', '.join(['<b>PyQt  %s' % PYQT_VERSION_STR,
-                                  'Mutagen %s' % mutagen.version_string,
-                                  'Pyparsing %s</b>' % pyparsing.__version__])
+        lib_versions = '<br />'.join(
+            ['%s: %s' % (lib, version) for (lib, version) in versions().items()]
+        )
+
         if changeset:
-            version = translate("About",
-                                '<h2>puddletag %1 (Changeset %2)</h2> %3')
+            version = translate("About", '<h2>puddletag %1</h2>Changeset %2')
             version = version.arg(version_string)
-            version = version.arg(changeset).arg(lib_versions)
+            version = version.arg(changeset)
         else:
-            version = translate("About",
-                                '<h2>puddletag %1</h2> %2')
+            version = translate("About", '<h2>puddletag %1</h2>')
             version = version.arg(version_string)
-            version = version.arg(lib_versions)
         label = QLabel(version)
 
         tab = QTabWidget()
         tab.addTab(ScrollLabel(desc), translate('About', '&About'))
         tab.addTab(ScrollLabel(thanks, Qt.AlignmentFlag.AlignLeft),
                    translate('About', '&Thanks'))
+        tab.addTab(ScrollLabel(lib_versions, Qt.AlignmentFlag.AlignLeft),
+                   translate('About', '&Libraries'))
 
         vbox = QVBoxLayout()
         version_layout = QHBoxLayout()


### PR DESCRIPTION
## Fix changeset detection
With 7f1fa4f2 the `puddlestuff` package was moved and as a result its
relative path/position to the git root changed. The changeset detection
has been updated to accommodate the new location.
And since I was at it, also replaced the usage of hardcoded `/` with
`os.path.join()`, and changed from the `master` branch to `HEAD` which
always points to the current commit. The downside is that `HEAD` can
contain references, but the upside is that it now also works for tags
and all other commits.
This solution does not require deps like `gitpython` or assumes the
`git` command is avilable (though that would be resonable).

## Slightly reorganize about dialogue
Moved the library versions to its own tab, so we have more space for
more and it can be easily copied. And moved the version logic into a
separate function, in the hope we can reuse that for e.g. #552.
Also moved the changeset to the line below the puddletag version one.
I intentionally did not update the translation resources, since they
are minor and there are already translation rework efforts going on.

## Extend dependency versions
They now encompass everything from `requirements.in` plus Python and Qt.
The version determination first tries to use the new
`importlib.metadata` package that was finally added with python v3.10,
and falls back to loading the module and reading the `__version__`
attribute.

![puddletag_about](https://user-images.githubusercontent.com/97832352/153793434-12edab3a-e334-4a8b-a73f-ed52bbaf1499.png)