### PR TITLE
Fix crashes on 'Format value'

### DIFF
--- a/puddlestuff/functions.py
+++ b/puddlestuff/functions.py
@@ -711,7 +711,7 @@ class RegHelper(object):
             return '""'
 
 
-def replaceWithReg(m_tags, text, regex, repl, matchcase=False, m_text=None, state=None):
+def replaceWithReg(m_tags, text, regex, repl=None, matchcase=False, m_text=None, state=None):
     """Replace with RegExp, "RegReplace $0: RegExp '$1' with '$2', Match Case: $3"
 &Regular Expression, text
 Replace &matches with:, text


### PR DESCRIPTION
Puddletag kept crashing when trying to select "Format Value" (Actions -> Actions / Quick Actions -> Add / Edit -> Add function -> Format Value).
Proposed PR appears to fix the issue.

> Traceback (most recent call last):
>   File "/usr/lib/python3.10/site-packages/puddlestuff/actiondlg.py", line 364, in showexample
>     val = apply_actions([self.func], audio, state, fields)
>   File "/usr/lib/python3.10/site-packages/puddlestuff/findfunc.py", line 620, in apply_actions
>     temp = func.runFunction(val, audio, state, None, r_tags)
>   File "/usr/lib/python3.10/site-packages/puddlestuff/findfunc.py", line 870, in runFunction
>     return func(**topass)
>   File "/usr/lib/python3.10/site-packages/puddlestuff/functions.py", line 204, in formatValue
>     ret = findfunc.parsefunc(p_pattern, m_tags, state=state)
>   File "/usr/lib/python3.10/site-packages/puddlestuff/findfunc.py", line 462, in parsefunc
>     func_parsed = run_format_func(func[0], func[1:], m_audio, s_audio, state=state, extra=extra)
>   File "/usr/lib/python3.10/site-packages/puddlestuff/findfunc.py", line 328, in run_format_func
>     message = message.arg(arglen_error(e, topass, func, False))
>   File "/usr/lib/python3.10/site-packages/puddlestuff/findfunc.py", line 71, in arglen_error
>     raise e
>   File "/usr/lib/python3.10/site-packages/puddlestuff/findfunc.py", line 322, in run_format_func
>     ret = func(**topass)
> TypeError: replaceWithReg() missing 1 required positional argument: 'repl'
> [1]    4305 IOT instruction (core dumped)  puddletag -d