### PR TITLE
Use PyQt Scoped Enums

### DIFF
--- a/puddlestuff/about.py
+++ b/puddlestuff/about.py
@@ -47,7 +47,7 @@ class ScrollLabel(QWidget):
         label.setTextFormat(Qt.TextFormat.RichText)
         label.setAlignment(alignment)
         label.setWordWrap(True)
-        label.setTextInteractionFlags(Qt.TextBrowserInteraction)
+        label.setTextInteractionFlags(Qt.TextInteractionFlag.TextBrowserInteraction)
 
         sa = QScrollArea()
         sa.setWidget(label)

--- a/puddlestuff/about.py
+++ b/puddlestuff/about.py
@@ -44,7 +44,7 @@ class ScrollLabel(QWidget):
         self.setLayout(vbox)
         label = QLabel(text)
 
-        label.setTextFormat(Qt.RichText)
+        label.setTextFormat(Qt.TextFormat.RichText)
         label.setAlignment(alignment)
         label.setWordWrap(True)
         label.setTextInteractionFlags(Qt.TextBrowserInteraction)

--- a/puddlestuff/about.py
+++ b/puddlestuff/about.py
@@ -38,7 +38,7 @@ The <b>Oxygen team</b> for the Oxygen icons.
 
 
 class ScrollLabel(QWidget):
-    def __init__(self, text, alignment=Qt.AlignCenter, parent=None):
+    def __init__(self, text, alignment=Qt.AlignmentFlag.AlignCenter, parent=None):
         QWidget.__init__(self, parent)
         vbox = QVBoxLayout()
         self.setLayout(vbox)
@@ -79,7 +79,7 @@ class AboutPuddletag(QDialog):
 
         tab = QTabWidget()
         tab.addTab(ScrollLabel(desc), translate('About', '&About'))
-        tab.addTab(ScrollLabel(thanks, Qt.AlignLeft),
+        tab.addTab(ScrollLabel(thanks, Qt.AlignmentFlag.AlignLeft),
                    translate('About', '&Thanks'))
 
         vbox = QVBoxLayout()

--- a/puddlestuff/action_shortcuts.py
+++ b/puddlestuff/action_shortcuts.py
@@ -205,7 +205,7 @@ class Editor(QDialog):
         new_item._action = item._action
         self._newActionList.addItem(new_item)
         self._newActionList.setCurrentItem(new_item,
-                                           QItemSelectionModel.ClearAndSelect)
+                                           QItemSelectionModel.SelectionFlag.ClearAndSelect)
 
     def enableOk(self, text):
         if not text or text in self._names:
@@ -300,7 +300,7 @@ class ShortcutEditor(QDialog):
         item.shortcut = shortcut
         self._listbox.addItem(item)
         if select:
-            self._listbox.setCurrentItem(item, QItemSelectionModel.ClearAndSelect)
+            self._listbox.setCurrentItem(item, QItemSelectionModel.SelectionFlag.ClearAndSelect)
 
     def applySettings(self, control=None):
         from .puddletag import remove_shortcuts, add_shortcuts

--- a/puddlestuff/actiondlg.py
+++ b/puddlestuff/actiondlg.py
@@ -142,7 +142,7 @@ class ScrollLabel(QScrollArea):
         self.setText(text)
         self.text = label.text
         label.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Preferred)
-        self.setFrameStyle(QFrame.NoFrame)
+        self.setFrameStyle(QFrame.Shape.NoFrame)
         self.setWidgetResizable(True)
         self.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
         self.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
@@ -486,7 +486,7 @@ class CreateFunction(QDialog):
     def createWindow(self, index, fields=None, args=None):
         """Creates a Function dialog in the stack window
         if it doesn't exist already."""
-        self.stack.setFrameStyle(QFrame.Box)
+        self.stack.setFrameStyle(QFrame.Shape.Box)
         if index not in self.stackWidgets:
             widget = FunctionDialog(self.realfuncs[index],
                                     self.selectedFields, args, fields,

--- a/puddlestuff/actiondlg.py
+++ b/puddlestuff/actiondlg.py
@@ -726,7 +726,7 @@ class ActionWindow(QDialog):
 
         for i, m in sorted(self.macros.items()):
             item = QListWidgetItem(m.name)
-            item.setFlags(item.flags() | Qt.ItemIsEditable)
+            item.setFlags(item.flags() | Qt.ItemFlag.ItemIsEditable)
             if m.name in to_check:
                 item.setCheckState(Qt.CheckState.Checked)
             else:
@@ -975,7 +975,7 @@ class ActionWindow(QDialog):
         if (ok is True) and text:
             item = QListWidgetItem(text)
             item.setCheckState(Qt.CheckState.Unchecked)
-            item.setFlags(item.flags() | Qt.ItemIsEditable)
+            item.setFlags(item.flags() | Qt.ItemFlag.ItemIsEditable)
             self.listbox.addItem(item)
         else:
             return
@@ -1077,7 +1077,7 @@ class ActionWindow(QDialog):
     def duplicateBuddy(self, name, actions):
         item = QListWidgetItem(name)
         item.setCheckState(Qt.CheckState.Unchecked)
-        item.setFlags(item.flags() | Qt.ItemIsEditable)
+        item.setFlags(item.flags() | Qt.ItemFlag.ItemIsEditable)
         self.listbox.addItem(item)
 
         m = Macro()

--- a/puddlestuff/actiondlg.py
+++ b/puddlestuff/actiondlg.py
@@ -269,9 +269,9 @@ class FunctionDialog(QWidget):
             newargs = []
             for method in self.retval:
                 if method.__name__ == 'checkState':
-                    if method() == Qt.Checked:
+                    if method() == Qt.CheckState.Checked:
                         newargs.append(True)
-                    elif (method() == Qt.PartiallyChecked) or (method() == Qt.Unchecked):
+                    elif (method() == Qt.CheckState.PartiallyChecked) or (method() == Qt.CheckState.Unchecked):
                         newargs.append(False)
                 else:
                     if isinstance(method(), int):
@@ -728,9 +728,9 @@ class ActionWindow(QDialog):
             item = QListWidgetItem(m.name)
             item.setFlags(item.flags() | Qt.ItemIsEditable)
             if m.name in to_check:
-                item.setCheckState(Qt.Checked)
+                item.setCheckState(Qt.CheckState.Checked)
             else:
-                item.setCheckState(Qt.Unchecked)
+                item.setCheckState(Qt.CheckState.Unchecked)
             self.listbox.addItem(item)
 
         self.okcancel = OKCancel()
@@ -846,7 +846,7 @@ class ActionWindow(QDialog):
     def enableOK(self, val):
         item = self.listbox.item
         enable = [row for row in range(self.listbox.count()) if
-                  item(row).checkState() == Qt.Checked]
+                  item(row).checkState() == Qt.CheckState.Checked]
         if enable:
             self.okcancel.okButton.setEnabled(True)
             self.shortcutButton.setEnabled(True)
@@ -923,7 +923,7 @@ class ActionWindow(QDialog):
             return
         l = self.listbox
         items = [l.item(z) for z in range(l.count())]
-        selectedrows = [i for i, z in enumerate(items) if z.checkState() == Qt.Checked]
+        selectedrows = [i for i, z in enumerate(items) if z.checkState() == Qt.CheckState.Checked]
 
         if selectedrows:
             from .puddletag import status
@@ -974,7 +974,7 @@ class ActionWindow(QDialog):
 
         if (ok is True) and text:
             item = QListWidgetItem(text)
-            item.setCheckState(Qt.Unchecked)
+            item.setCheckState(Qt.CheckState.Unchecked)
             item.setFlags(item.flags() | Qt.ItemIsEditable)
             self.listbox.addItem(item)
         else:
@@ -1015,7 +1015,7 @@ class ActionWindow(QDialog):
         l = self.listbox
         items = [l.item(z) for z in range(l.count())]
         checked = [i for i, z in enumerate(items) if
-                   z.checkState() == Qt.Checked]
+                   z.checkState() == Qt.CheckState.Checked]
         return checked
 
     def saveChecked(self):
@@ -1076,7 +1076,7 @@ class ActionWindow(QDialog):
 
     def duplicateBuddy(self, name, actions):
         item = QListWidgetItem(name)
-        item.setCheckState(Qt.Unchecked)
+        item.setCheckState(Qt.CheckState.Unchecked)
         item.setFlags(item.flags() | Qt.ItemIsEditable)
         self.listbox.addItem(item)
 

--- a/puddlestuff/actiondlg.py
+++ b/puddlestuff/actiondlg.py
@@ -715,7 +715,7 @@ class ActionWindow(QDialog):
         self._quickaction = quickaction
         self.listbox = ListBox()
         self.listbox.setSelectionMode(QAbstractItemView.ExtendedSelection)
-        self.listbox.setEditTriggers(QAbstractItemView.EditKeyPressed)
+        self.listbox.setEditTriggers(QAbstractItemView.EditTrigger.EditKeyPressed)
 
         self.example = example
 

--- a/puddlestuff/actiondlg.py
+++ b/puddlestuff/actiondlg.py
@@ -145,7 +145,7 @@ class ScrollLabel(QScrollArea):
         self.setFrameStyle(QFrame.NoFrame)
         self.setWidgetResizable(True)
         self.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
-        self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
 
     def wheelEvent(self, e):
         h = self.horizontalScrollBar()

--- a/puddlestuff/actiondlg.py
+++ b/puddlestuff/actiondlg.py
@@ -714,7 +714,7 @@ class ActionWindow(QDialog):
         self._shortcuts = []
         self._quickaction = quickaction
         self.listbox = ListBox()
-        self.listbox.setSelectionMode(QAbstractItemView.ExtendedSelection)
+        self.listbox.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
         self.listbox.setEditTriggers(QAbstractItemView.EditTrigger.EditKeyPressed)
 
         self.example = example

--- a/puddlestuff/actiondlg.py
+++ b/puddlestuff/actiondlg.py
@@ -141,7 +141,7 @@ class ScrollLabel(QScrollArea):
         self.setWidget(label)
         self.setText(text)
         self.text = label.text
-        label.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Preferred)
+        label.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Preferred)
         self.setFrameStyle(QFrame.Shape.NoFrame)
         self.setWidgetResizable(True)
         self.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)

--- a/puddlestuff/actiondlg.py
+++ b/puddlestuff/actiondlg.py
@@ -144,7 +144,7 @@ class ScrollLabel(QScrollArea):
         label.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Preferred)
         self.setFrameStyle(QFrame.NoFrame)
         self.setWidgetResizable(True)
-        self.setAlignment(Qt.AlignLeft | Qt.AlignTop)
+        self.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
         self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
 
     def wheelEvent(self, e):

--- a/puddlestuff/actiondlg.py
+++ b/puddlestuff/actiondlg.py
@@ -970,7 +970,7 @@ class ActionWindow(QDialog):
         (text, ok) = QInputDialog.getText(self,
                                           translate('Actions', "New Action"),
                                           translate('Actions', "Enter a name for the new action."),
-                                          QLineEdit.Normal)
+                                          QLineEdit.EchoMode.Normal)
 
         if (ok is True) and text:
             item = QListWidgetItem(text)
@@ -1059,7 +1059,7 @@ class ActionWindow(QDialog):
         (text, ok) = QInputDialog.getText(self,
                                           translate('Actions', "Copy %s action" % oldname),
                                           translate('Actions', "Enter a name for the new action."),
-                                          QLineEdit.Normal)
+                                          QLineEdit.EchoMode.Normal)
         if not (ok and text):
             return
 

--- a/puddlestuff/constants.py
+++ b/puddlestuff/constants.py
@@ -81,10 +81,10 @@ MUSICLIBS = 'MUSICLIBS'
 MODULES = 'MODULES'
 
 # Dock Positions
-LEFTDOCK = Qt.LeftDockWidgetArea
-RIGHTDOCK = Qt.RightDockWidgetArea
-BOTTOMDOCK = Qt.BottomDockWidgetArea
-TOPDOCK = Qt.TopDockWidgetArea
+LEFTDOCK = Qt.DockWidgetArea.LeftDockWidgetArea
+RIGHTDOCK = Qt.DockWidgetArea.RightDockWidgetArea
+BOTTOMDOCK = Qt.DockWidgetArea.BottomDockWidgetArea
+TOPDOCK = Qt.DockWidgetArea.TopDockWidgetArea
 
 # Tag constants
 PATH = "__path"

--- a/puddlestuff/duplicates/algwin.py
+++ b/puddlestuff/duplicates/algwin.py
@@ -345,7 +345,7 @@ class SetDialog(QDialog):
     def addSet(self):
         def gettext():
             (text, ok) = QInputDialog.getText(self, 'puddletag', 'Enter a name'
-                                                                 'for the set', QLineEdit.Normal)
+                                                                 'for the set', QLineEdit.EchoMode.Normal)
             if ok:
                 if self.setscombo.findText(text) > -1:
                     QMessageBox.information(self, 'puddletag', 'The name entered already exists.')

--- a/puddlestuff/duplicates/algwin.py
+++ b/puddlestuff/duplicates/algwin.py
@@ -257,16 +257,16 @@ class AlgWin(QWidget):
         self.tags.setText(' | '.join(alg.tags))
         self.threshold.setText('%.2f' % (alg.threshold * 100))
         if alg.matchcase:
-            self.matchcase.setCheckState(Qt.Checked)
+            self.matchcase.setCheckState(Qt.CheckState.Checked)
         else:
-            self.matchcase.setCheckState(Qt.Unchecked)
+            self.matchcase.setCheckState(Qt.CheckState.Unchecked)
 
     def saveAlgo(self):
         tags = [x for x in [z.strip() for z in str(self.tags.text()).split("|")] if x != ""]
         func = funcs[self.alcombo.currentIndex()]
         threshold = float(str(self.threshold.text())) / 100
         matchcase = False
-        if self.matchcase.checkState() == Qt.Checked:
+        if self.matchcase.checkState() == Qt.CheckState.Checked:
             matchcase = True
 
         return Algo(tags, threshold, func, matchcase)

--- a/puddlestuff/duplicates/algwin.py
+++ b/puddlestuff/duplicates/algwin.py
@@ -226,7 +226,7 @@ class AlgWin(QWidget):
         [vbox.addWidget(z) for z in [taglabel, self.tags, perlabel, self.threshold,
                                      allabel, self.alcombo, self.matchcase]]
         frame = QFrame()
-        frame.setFrameStyle(QFrame.Box)
+        frame.setFrameStyle(QFrame.Shape.Box)
         frame.setLayout(vbox)
 
         box = QVBoxLayout()

--- a/puddlestuff/duplicates/algwin.py
+++ b/puddlestuff/duplicates/algwin.py
@@ -142,7 +142,7 @@ class DupeTree(QTreeWidget):
 
     # def mouseMoveEvent(self, event):
     # QTreeWidget.mouseMoveEvent(self, event)
-    # if event.buttons() != Qt.LeftButton:
+    # if event.buttons() != Qt.MouseButton.LeftButton:
     # return
     # mimeData = QMimeData()
     # plainText = ""
@@ -167,11 +167,11 @@ class DupeTree(QTreeWidget):
     # dropaction = drag.exec_(self.dropaction)
 
     # def mousePressEvent(self, event):
-    # if event.buttons() == Qt.RightButton:
+    # if event.buttons() == Qt.MouseButton.RightButton:
     # e = QContextMenuEvent(QContextMenuEvent.Mouse, event.pos(), event.globalPos())
     # self.contextMenuEvent(e)
     # return
-    # if event.buttons() == Qt.LeftButton:
+    # if event.buttons() == Qt.MouseButton.LeftButton:
     # self.StartPosition = [event.pos().x(), event.pos().y()]
     # QTreeWidget.mousePressEvent(self, event)
 

--- a/puddlestuff/duplicates/algwin.py
+++ b/puddlestuff/duplicates/algwin.py
@@ -168,7 +168,7 @@ class DupeTree(QTreeWidget):
 
     # def mousePressEvent(self, event):
     # if event.buttons() == Qt.MouseButton.RightButton:
-    # e = QContextMenuEvent(QContextMenuEvent.Mouse, event.pos(), event.globalPos())
+    # e = QContextMenuEvent(QContextMenuEvent.Reason.Mouse, event.pos(), event.globalPos())
     # self.contextMenuEvent(e)
     # return
     # if event.buttons() == Qt.MouseButton.LeftButton:

--- a/puddlestuff/genres.py
+++ b/puddlestuff/genres.py
@@ -37,7 +37,7 @@ class Genres(QWidget):
             genres = status['genres']
 
         self.listbox = ListBox()
-        self._itemflags = Qt.ItemIsSelectable | Qt.ItemIsEditable | Qt.ItemIsEnabled
+        self._itemflags = Qt.ItemFlag.ItemIsSelectable | Qt.ItemFlag.ItemIsEditable | Qt.ItemFlag.ItemIsEnabled
         [self.listbox.addItem(self._createItem(z)) for z in genres]
 
         buttons = ListButtons()

--- a/puddlestuff/helperwin.py
+++ b/puddlestuff/helperwin.py
@@ -669,7 +669,7 @@ class ExTags(QDialog):
         self.listbuttons.movedownButton.hide()
 
         listframe = QFrame()
-        listframe.setFrameStyle(QFrame.Box)
+        listframe.setFrameStyle(QFrame.Shape.Box)
         hbox = QHBoxLayout()
         hbox.addWidget(self.table, 1)
         hbox.addLayout(self.listbuttons, 0)
@@ -678,7 +678,7 @@ class ExTags(QDialog):
         layout = QVBoxLayout()
         if artwork:
             imageframe = QFrame()
-            imageframe.setFrameStyle(QFrame.Box)
+            imageframe.setFrameStyle(QFrame.Shape.Box)
             vbox = QVBoxLayout()
             vbox.setContentsMargins(0, 0, 0, 0)
             vbox.addWidget(self.piclabel)

--- a/puddlestuff/helperwin.py
+++ b/puddlestuff/helperwin.py
@@ -233,7 +233,7 @@ class ImportTextFile(QDialog):
 
         self.tags = QTextEdit()
         grid.addWidget(self.tags, 1, 2, 1, 2)
-        self.tags.setLineWrapMode(QTextEdit.NoWrap)
+        self.tags.setLineWrapMode(QTextEdit.LineWrapMode.NoWrap)
 
         hbox = QHBoxLayout()
 

--- a/puddlestuff/helperwin.py
+++ b/puddlestuff/helperwin.py
@@ -632,7 +632,7 @@ class ExTags(QDialog):
         header.setVisible(True)
         header.setSortIndicatorShown(True)
         header.setStretchLastSection(True)
-        header.setSortIndicator(0, Qt.AscendingOrder)
+        header.setSortIndicator(0, Qt.SortOrder.AscendingOrder)
 
         self.piclabel = PicWidget(buttons=True)
         self.piclabel.imageChanged.connect(

--- a/puddlestuff/helperwin.py
+++ b/puddlestuff/helperwin.py
@@ -498,7 +498,7 @@ class StatusWidgetItem(QTableWidgetItem):
 
 class VerticalHeader(QHeaderView):
     def __init__(self, parent=None):
-        QHeaderView.__init__(self, Qt.Vertical, parent)
+        QHeaderView.__init__(self, Qt.Orientation.Vertical, parent)
         self.setDefaultSectionSize(self.minimumSectionSize() + 4)
         self.setMinimumSectionSize(1)
 

--- a/puddlestuff/helperwin.py
+++ b/puddlestuff/helperwin.py
@@ -121,7 +121,7 @@ class AutonumberDialog(QDialog):
         okcancel.ok.connect(self.emitValuesAndSave)
         okcancel.cancel.connect(self.close)
         self._separator.stateChanged.connect(
-            lambda v: self._numtracks.setEnabled(v == Qt.Checked))
+            lambda v: self._numtracks.setEnabled(v == Qt.CheckState.Checked))
 
         # self._restart_numbering.stateChanged.connect(
         #              self.showDirectorySplittingOptions)
@@ -131,7 +131,7 @@ class AutonumberDialog(QDialog):
         self._loadSettings()
 
     def showDirectorySplittingOptions(self, state):
-        is_checked = state == Qt.Checked
+        is_checked = state == Qt.CheckState.Checked
         for widget in self.custom_numbering_widgets:
             widget.setVisible(is_checked)
 
@@ -175,14 +175,14 @@ class AutonumberDialog(QDialog):
         section = 'autonumbering'
         self._start.setValue(cparser.get(section, 'start', 1))
         self._separator.setCheckState(
-            cparser.get(section, 'separator', Qt.Unchecked))
+            cparser.get(section, 'separator', Qt.CheckState.Unchecked))
         self._padlength.setValue(cparser.get(section, 'padlength', 1))
 
         self._restart_numbering.setCheckState(
-            cparser.get(section, 'restart', Qt.Unchecked))
+            cparser.get(section, 'restart', Qt.CheckState.Unchecked))
 
         self.count_by_group.setCheckState(
-            cparser.get(section, 'count_by_group', Qt.Unchecked))
+            cparser.get(section, 'count_by_group', Qt.CheckState.Unchecked))
 
         self.showDirectorySplittingOptions(self._restart_numbering.checkState())
 

--- a/puddlestuff/helperwin.py
+++ b/puddlestuff/helperwin.py
@@ -320,7 +320,7 @@ class ImportTextFile(QDialog):
                                        translate('Text File -> Tag', "Error"),
                                        translate('Text File -> Tag', errormsg.arg(filename)))
 
-            if ret == QMessageBox.Yes:
+            if ret == QMessageBox.StandardButton.Yes:
                 return self.openFile()
             else:
                 return detail

--- a/puddlestuff/helperwin.py
+++ b/puddlestuff/helperwin.py
@@ -801,7 +801,7 @@ class ExTags(QDialog):
                     cur_item = self.table.item(self.table.currentRow(), 0)
                     self.resetFields([cur_item])
                     self.table.setCurrentItem(cur_item,
-                                              QItemSelectionModel.ClearAndSelect)
+                                              QItemSelectionModel.SelectionFlag.ClearAndSelect)
                     self.table.selectRow(self.table.row(cur_item))
                     self.removeField()
                     valitem = self._settag(rowcount, tag,

--- a/puddlestuff/helperwin.py
+++ b/puddlestuff/helperwin.py
@@ -451,7 +451,7 @@ class StatusWidgetItem(QTableWidgetItem):
             self.setBackground(self.statusColors[status])
 
         self._status = status
-        self.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled)
+        self.setFlags(Qt.ItemFlag.ItemIsSelectable | Qt.ItemFlag.ItemIsEnabled)
         self._original = (text, preview, status)
         self.linked = []
 

--- a/puddlestuff/helperwin.py
+++ b/puddlestuff/helperwin.py
@@ -101,7 +101,7 @@ class AutonumberDialog(QDialog):
 
         self.output_field.setEditable(True)
         completer = self.output_field.completer()
-        completer.setCaseSensitivity(Qt.CaseSensitive)
+        completer.setCaseSensitivity(Qt.CaseSensitivity.CaseSensitive)
         completer.setCompletionMode(QCompleter.UnfilteredPopupCompletion)
 
         self.output_field.setCompleter(completer)
@@ -394,7 +394,7 @@ class EditField(QDialog):
         self.tagcombo.setEditable(True)
         label.setBuddy(self.tagcombo)
         completer = self.tagcombo.completer()
-        completer.setCaseSensitivity(Qt.CaseSensitive)
+        completer.setCaseSensitivity(Qt.CaseSensitivity.CaseSensitive)
         completer.setCompletionMode(QCompleter.UnfilteredPopupCompletion)
         self.tagcombo.setCompleter(completer)
         self.tagcombo.addItems(field_list if field_list else gettaglist())

--- a/puddlestuff/helperwin.py
+++ b/puddlestuff/helperwin.py
@@ -1134,7 +1134,7 @@ class ConfirmationErrorDialog(QDialog):
         self.__label = QLabel()
         icon = QLabel()
         msgbox = QMessageBox()
-        msgbox.setIcon(QMessageBox.Warning)
+        msgbox.setIcon(QMessageBox.Icon.Warning)
         icon.setPixmap(msgbox.iconPixmap())
         ok = QPushButton(translate("Defaults", "OK"))
         checkbox = QCheckBox(

--- a/puddlestuff/helperwin.py
+++ b/puddlestuff/helperwin.py
@@ -102,7 +102,7 @@ class AutonumberDialog(QDialog):
         self.output_field.setEditable(True)
         completer = self.output_field.completer()
         completer.setCaseSensitivity(Qt.CaseSensitivity.CaseSensitive)
-        completer.setCompletionMode(QCompleter.UnfilteredPopupCompletion)
+        completer.setCompletionMode(QCompleter.CompletionMode.UnfilteredPopupCompletion)
 
         self.output_field.setCompleter(completer)
         self.output_field.addItems(gettaglist())
@@ -395,7 +395,7 @@ class EditField(QDialog):
         label.setBuddy(self.tagcombo)
         completer = self.tagcombo.completer()
         completer.setCaseSensitivity(Qt.CaseSensitivity.CaseSensitive)
-        completer.setCompletionMode(QCompleter.UnfilteredPopupCompletion)
+        completer.setCompletionMode(QCompleter.CompletionMode.UnfilteredPopupCompletion)
         self.tagcombo.setCompleter(completer)
         self.tagcombo.addItems(field_list if field_list else gettaglist())
 

--- a/puddlestuff/helperwin.py
+++ b/puddlestuff/helperwin.py
@@ -623,7 +623,7 @@ class ExTags(QDialog):
         self.table.setVerticalHeader(VerticalHeader())
         self.table.verticalHeader().setVisible(False)
         self.table.setSortingEnabled(True)
-        self.table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.table.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
         self.table.setHorizontalHeaderLabels([
             translate('Extended Tags', 'Field'),
             translate('Extended Tags', 'Value')])

--- a/puddlestuff/helperwin.py
+++ b/puddlestuff/helperwin.py
@@ -563,14 +563,14 @@ class StatusWidgetCombo(QComboBox):
 
     def setBackground(self, brush=None):
         if brush is None:
-            color = QLineEdit().palette().color(QPalette.Base).name()
+            color = QLineEdit().palette().color(QPalette.ColorRole.Base).name()
         else:
             color = brush.color().name()
         self.setStyleSheet("QComboBox { background-color: %s; }" % color);
 
     def background(self):
         brush = QBrush()
-        brush.setColor(self.palette().color(QPalette.Background))
+        brush.setColor(self.palette().color(QPalette.ColorRole.Background))
         return brush
 
     def reset(self):

--- a/puddlestuff/helperwin.py
+++ b/puddlestuff/helperwin.py
@@ -1148,8 +1148,8 @@ class ConfirmationErrorDialog(QDialog):
 
         layout = QVBoxLayout()
         layout.addLayout(labelbox, 1)
-        layout.addWidget(checkbox, 0, Qt.AlignHCenter)
-        layout.addWidget(ok, 0, Qt.AlignHCenter)
+        layout.addWidget(checkbox, 0, Qt.AlignmentFlag.AlignHCenter)
+        layout.addWidget(ok, 0, Qt.AlignmentFlag.AlignHCenter)
         layout.addStretch()
         self.setLayout(layout)
 

--- a/puddlestuff/helperwin.py
+++ b/puddlestuff/helperwin.py
@@ -515,7 +515,7 @@ class StatusWidgetCombo(QComboBox):
         self.preview = preview
 
         self.statusColors = colors
-        self.setSizeAdjustPolicy(QComboBox.AdjustToMinimumContentsLength)
+        self.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToMinimumContentsLength)
 
         items = map(str, items)
         items = sorted(items, key=natsort_case_key)

--- a/puddlestuff/libraries/amarok.py
+++ b/puddlestuff/libraries/amarok.py
@@ -253,7 +253,7 @@ class ConfigWindow(QWidget):
 
         passlabel = QLabel('&Password')
         self.passwd = QLineEdit()
-        self.passwd.setEchoMode(QLineEdit.Password)
+        self.passwd.setEchoMode(QLineEdit.EchoMode.Password)
         passlabel.setBuddy(self.passwd)
 
         datalabel = QLabel('&Database')

--- a/puddlestuff/libraries/prokyon.py
+++ b/puddlestuff/libraries/prokyon.py
@@ -377,7 +377,7 @@ class ConfigWindow(QWidget):
 
         passlabel = QLabel('&Password')
         self.passwd = QLineEdit()
-        self.passwd.setEchoMode(QLineEdit.Password)
+        self.passwd.setEchoMode(QLineEdit.EchoMode.Password)
         passlabel.setBuddy(self.passwd)
 
         datalabel = QLabel('&Database')

--- a/puddlestuff/libraries/quodlibetlib.py
+++ b/puddlestuff/libraries/quodlibetlib.py
@@ -340,7 +340,7 @@ class DirLineEdit(QLineEdit):
         completer = QCompleter()
         completer.setCompletionMode(QCompleter.CompletionMode.PopupCompletion)
         dirfilter = QDir.Filter.AllEntries | QDir.Filter.NoDotAndDotDot | QDir.Filter.Hidden
-        sortflags = QDir.DirsFirst | QDir.IgnoreCase
+        sortflags = QDir.SortFlag.DirsFirst | QDir.SortFlag.IgnoreCase
 
         dirmodel = QDirModel(['*'], dirfilter, sortflags, completer)
         completer.setModel(dirmodel)

--- a/puddlestuff/libraries/quodlibetlib.py
+++ b/puddlestuff/libraries/quodlibetlib.py
@@ -339,7 +339,7 @@ class DirLineEdit(QLineEdit):
         super(DirLineEdit, self).__init__(*args, **kwargs)
         completer = QCompleter()
         completer.setCompletionMode(QCompleter.CompletionMode.PopupCompletion)
-        dirfilter = QDir.AllEntries | QDir.NoDotAndDotDot | QDir.Hidden
+        dirfilter = QDir.Filter.AllEntries | QDir.Filter.NoDotAndDotDot | QDir.Filter.Hidden
         sortflags = QDir.DirsFirst | QDir.IgnoreCase
 
         dirmodel = QDirModel(['*'], dirfilter, sortflags, completer)

--- a/puddlestuff/libraries/quodlibetlib.py
+++ b/puddlestuff/libraries/quodlibetlib.py
@@ -338,7 +338,7 @@ class DirLineEdit(QLineEdit):
     def __init__(self, *args, **kwargs):
         super(DirLineEdit, self).__init__(*args, **kwargs)
         completer = QCompleter()
-        completer.setCompletionMode(QCompleter.PopupCompletion)
+        completer.setCompletionMode(QCompleter.CompletionMode.PopupCompletion)
         dirfilter = QDir.AllEntries | QDir.NoDotAndDotDot | QDir.Hidden
         sortflags = QDir.DirsFirst | QDir.IgnoreCase
 

--- a/puddlestuff/libraries/quodlibetlib.py
+++ b/puddlestuff/libraries/quodlibetlib.py
@@ -325,8 +325,8 @@ class QuodLibet(object):
 
 class DirModel(QDirModel):
 
-    def data(self, index, role=Qt.DisplayRole):
-        if (role == Qt.DisplayRole and index.column() == 0):
+    def data(self, index, role=Qt.ItemDataRole.DisplayRole):
+        if (role == Qt.ItemDataRole.DisplayRole and index.column() == 0):
             path = QDir.toNativeSeparators(self.filePath(index))
             if path.endsWith(QDir.separator()):
                 path.chop(1)

--- a/puddlestuff/m3u.py
+++ b/puddlestuff/m3u.py
@@ -130,7 +130,7 @@ def exportm3u(tags, tofile, format=None, reldir=False, winsep=False):
 if __name__ == '__main__':
     app = QApplication(sys.argv)
     filedlg = QFileDialog()
-    filedlg.setFileMode(filedlg.DirectoryOnly)
+    filedlg.setFileMode(QFileDialog.FileMode.DirectoryOnly)
     filename = str(filedlg.getExistingDirectory(None,
                                                 'Open Folder'))
     tags = []

--- a/puddlestuff/mainwin/action_dialogs.py
+++ b/puddlestuff/mainwin/action_dialogs.py
@@ -41,9 +41,9 @@ class ActionDialog(ActionWindow):
         item = self.listbox.item
         for row in range(self.listbox.count()):
             if row in rows:
-                item(row).setCheckState(Qt.Checked)
+                item(row).setCheckState(Qt.CheckState.Checked)
             else:
-                item(row).setCheckState(Qt.Unchecked)
+                item(row).setCheckState(Qt.CheckState.Unchecked)
 
     def updateOrder(self):
         self.listbox.clear()
@@ -55,9 +55,9 @@ class ActionDialog(ActionWindow):
             item = QListWidgetItem(func_name)
             item.setFlags(item.flags() | Qt.ItemIsEditable)
             if func_name in to_check:
-                item.setCheckState(Qt.Checked)
+                item.setCheckState(Qt.CheckState.Checked)
             else:
-                item.setCheckState(Qt.Unchecked)
+                item.setCheckState(Qt.CheckState.Unchecked)
             self.listbox.addItem(item)
 
     def saveSettings(self):

--- a/puddlestuff/mainwin/action_dialogs.py
+++ b/puddlestuff/mainwin/action_dialogs.py
@@ -53,7 +53,7 @@ class ActionDialog(ActionWindow):
         for i, m in sorted(self.macros.items()):
             func_name = m.name
             item = QListWidgetItem(func_name)
-            item.setFlags(item.flags() | Qt.ItemIsEditable)
+            item.setFlags(item.flags() | Qt.ItemFlag.ItemIsEditable)
             if func_name in to_check:
                 item.setCheckState(Qt.CheckState.Checked)
             else:

--- a/puddlestuff/mainwin/artwork.py
+++ b/puddlestuff/mainwin/artwork.py
@@ -43,10 +43,10 @@ def create_svg(text, font, rect=None):
 
     painter = QPainter()
     painter.begin(generator)
-    painter.fillRect(rect, Qt.black)
+    painter.fillRect(rect, Qt.GlobalColor.black)
     painter.setFont(font)
-    painter.setPen(Qt.white)
-    painter.setBrush(QBrush(Qt.white))
+    painter.setPen(Qt.GlobalColor.white)
+    painter.setBrush(QBrush(Qt.GlobalColor.white))
     painter.drawText(rect, Qt.AlignmentFlag.AlignCenter, text)
     painter.end()
 

--- a/puddlestuff/mainwin/artwork.py
+++ b/puddlestuff/mainwin/artwork.py
@@ -47,7 +47,7 @@ def create_svg(text, font, rect=None):
     painter.setFont(font)
     painter.setPen(Qt.white)
     painter.setBrush(QBrush(Qt.white))
-    painter.drawText(rect, Qt.AlignCenter, text)
+    painter.drawText(rect, Qt.AlignmentFlag.AlignCenter, text)
     painter.end()
 
     svg = open(f.name).read()

--- a/puddlestuff/mainwin/dirview.py
+++ b/puddlestuff/mainwin/dirview.py
@@ -27,7 +27,7 @@ class DirView(QTreeView):
         # an index is clicked. See selectionChanged.
 
         dirmodel = QDirModel()
-        dirmodel.setSorting(QDir.IgnoreCase)
+        dirmodel.setSorting(QDir.SortFlag.IgnoreCase)
         dirmodel.setFilter(QDir.Filter.Dirs | QDir.Filter.NoDotAndDotDot)
         dirmodel.setReadOnly(False)
         dirmodel.setLazyChildCount(False)

--- a/puddlestuff/mainwin/dirview.py
+++ b/puddlestuff/mainwin/dirview.py
@@ -34,7 +34,7 @@ class DirView(QTreeView):
         dirmodel.setResolveSymlinks(False)
         header = PuddleHeader(Qt.Orientation.Horizontal, self)
         self.setHeader(header)
-        self.header().setSectionResizeMode(QHeaderView.ResizeToContents)
+        self.header().setSectionResizeMode(QHeaderView.ResizeMode.ResizeToContents)
 
         self.setModel(dirmodel)
         [self.hideColumn(column) for column in range(1, 4)]

--- a/puddlestuff/mainwin/dirview.py
+++ b/puddlestuff/mainwin/dirview.py
@@ -144,7 +144,7 @@ class DirView(QTreeView):
         self._load = True
 
     def loadSettings(self):
-        settings = QSettings(QT_CONFIG, QSettings.IniFormat)
+        settings = QSettings(QT_CONFIG, QSettings.Format.IniFormat)
         header = self.header()
         if settings.value('dirview/header'):
             header.restoreState(settings.value('dirview/header'))
@@ -256,7 +256,7 @@ class DirView(QTreeView):
         dirthread.start()
 
     def saveSettings(self):
-        settings = QSettings(QT_CONFIG, QSettings.IniFormat)
+        settings = QSettings(QT_CONFIG, QSettings.Format.IniFormat)
         settings.setValue('dirview/header',
                           self.header().saveState())
         settings.setValue('dirview/hide', self.isHeaderHidden())

--- a/puddlestuff/mainwin/dirview.py
+++ b/puddlestuff/mainwin/dirview.py
@@ -344,7 +344,7 @@ class DirViewWidget(QWidget):
         self.dirview.saveSettings()
 
     def setSubFolders(self, check):
-        if check == Qt.Checked:
+        if check == Qt.CheckState.Checked:
             value = True
         else:
             value = False

--- a/puddlestuff/mainwin/dirview.py
+++ b/puddlestuff/mainwin/dirview.py
@@ -28,7 +28,7 @@ class DirView(QTreeView):
 
         dirmodel = QDirModel()
         dirmodel.setSorting(QDir.IgnoreCase)
-        dirmodel.setFilter(QDir.Dirs | QDir.NoDotAndDotDot)
+        dirmodel.setFilter(QDir.Filter.Dirs | QDir.Filter.NoDotAndDotDot)
         dirmodel.setReadOnly(False)
         dirmodel.setLazyChildCount(False)
         dirmodel.setResolveSymlinks(False)

--- a/puddlestuff/mainwin/dirview.py
+++ b/puddlestuff/mainwin/dirview.py
@@ -2,7 +2,7 @@ import os
 
 from PyQt5.QtCore import QDir, QItemSelectionModel, QMutex, QSettings, QUrl, Qt, pyqtSignal
 from PyQt5.QtGui import QDesktopServices
-from PyQt5.QtWidgets import QAction, QCheckBox, QDirModel, QHeaderView, QMenu, QTreeView, QVBoxLayout, QWidget
+from PyQt5.QtWidgets import QAbstractItemView, QAction, QCheckBox, QDirModel, QHeaderView, QMenu, QTreeView, QVBoxLayout, QWidget
 
 from ..constants import LEFTDOCK, QT_CONFIG
 from ..puddleobjects import (PuddleConfig, PuddleThread,
@@ -41,7 +41,7 @@ class DirView(QTreeView):
 
         self.header().hide()
         self.subfolders = subfolders
-        self.setSelectionMode(self.ExtendedSelection)
+        self.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
         self._lastselection = 0  # If > 0 appends files. See selectionChanged
         self._load = True
         self.setDragEnabled(False)

--- a/puddlestuff/mainwin/dirview.py
+++ b/puddlestuff/mainwin/dirview.py
@@ -179,7 +179,7 @@ class DirView(QTreeView):
         thread.start()
 
     def mousePressEvent(self, event):
-        if event.buttons() == Qt.RightButton:
+        if event.buttons() == Qt.MouseButton.RightButton:
             return
         else:
             super(DirView, self).mousePressEvent(event)

--- a/puddlestuff/mainwin/dirview.py
+++ b/puddlestuff/mainwin/dirview.py
@@ -72,7 +72,7 @@ class DirView(QTreeView):
         smodel = self.selectionModel()
         smodel.blockSignals(True)
         smodel.clear()
-        smodel.select(deselected, smodel.Select)
+        smodel.select(deselected, QItemSelectionModel.SelectionFlag.Select)
         smodel.blockSignals(False)
         self._select = select
         return True
@@ -242,7 +242,7 @@ class DirView(QTreeView):
             if select:
                 self.setCurrentIndex(select[0])
                 self.scrollTo(select[0])
-            [selectindex(z, QItemSelectionModel.Select) for z in select]
+            [selectindex(z, QItemSelectionModel.SelectionFlag.Select) for z in select]
             if expand:
                 [self.expand(z) for z in expand]
             self.blockSignals(False)
@@ -293,7 +293,7 @@ class DirView(QTreeView):
     def selectIndex(self, index):
         if not index.isValid():
             return
-        self.selectionModel().select(index, QItemSelectionModel.Select)
+        self.selectionModel().select(index, QItemSelectionModel.SelectionFlag.Select)
         parent = index.parent()
         while parent.isValid():
             self.expand(index)

--- a/puddlestuff/mainwin/dirview.py
+++ b/puddlestuff/mainwin/dirview.py
@@ -32,7 +32,7 @@ class DirView(QTreeView):
         dirmodel.setReadOnly(False)
         dirmodel.setLazyChildCount(False)
         dirmodel.setResolveSymlinks(False)
-        header = PuddleHeader(Qt.Horizontal, self)
+        header = PuddleHeader(Qt.Orientation.Horizontal, self)
         self.setHeader(header)
         self.header().setSectionResizeMode(QHeaderView.ResizeToContents)
 

--- a/puddlestuff/mainwin/dirview.py
+++ b/puddlestuff/mainwin/dirview.py
@@ -47,7 +47,7 @@ class DirView(QTreeView):
         self.setDragEnabled(False)
         self.setAcceptDrops(True)
         self.setDropIndicatorShown(True)
-        self._dropaction = Qt.MoveAction
+        self._dropaction = Qt.DropAction.MoveAction
         self._threadRunning = False
 
         self._select = True

--- a/puddlestuff/mainwin/funcs.py
+++ b/puddlestuff/mainwin/funcs.py
@@ -161,7 +161,7 @@ def check_copy_data(data):
                                  "It may cause your system to lock up.\n\n"
                                  "Do you want to go ahead?"))
 
-        msgbox.setIcon(QMessageBox.Question)
+        msgbox.setIcon(QMessageBox.Icon.Question)
         yesBtn = msgbox.addButton(translate("Defaults", "&Yes"),
                                   QMessageBox.ButtonRole.YesRole)
         noBtn = msgbox.addButton(translate("Defaults", "No"),

--- a/puddlestuff/mainwin/funcs.py
+++ b/puddlestuff/mainwin/funcs.py
@@ -163,13 +163,13 @@ def check_copy_data(data):
 
         msgbox.setIcon(QMessageBox.Question)
         yesBtn = msgbox.addButton(translate("Defaults", "&Yes"),
-                                  QMessageBox.YesRole)
+                                  QMessageBox.ButtonRole.YesRole)
         noBtn = msgbox.addButton(translate("Defaults", "No"),
-                                 QMessageBox.NoRole)
+                                 QMessageBox.ButtonRole.NoRole)
         msgbox.setDefaultButton(noBtn)
         msgbox.setEscapeButton(noBtn)
         noImgBtn = msgbox.addButton(translate("Messages", "Copy without images."),
-                                    QMessageBox.ApplyRole)
+                                    QMessageBox.ButtonRole.ApplyRole)
 
         msgbox.exec_()
 

--- a/puddlestuff/mainwin/logdialog.py
+++ b/puddlestuff/mainwin/logdialog.py
@@ -15,7 +15,7 @@ class LogDialog(QWidget):
         self.receives = [('logappend', self.appendText)]
 
         self._text = QTextEdit()
-        self._text.setWordWrapMode(QTextOption.NoWrap)
+        self._text.setWordWrapMode(QTextOption.WrapMode.NoWrap)
 
         copy = QPushButton(translate("Logs", '&Copy'))
         clear = QPushButton(translate("Logs", '&Clear'))

--- a/puddlestuff/mainwin/patterncombo.py
+++ b/puddlestuff/mainwin/patterncombo.py
@@ -1,7 +1,7 @@
 import sys
 
 from PyQt5.QtCore import Qt, pyqtSignal
-from PyQt5.QtWidgets import QApplication, QComboBox, QFrame, QHBoxLayout, QInputDialog, QPushButton, \
+from PyQt5.QtWidgets import QAbstractItemView, QApplication, QComboBox, QFrame, QHBoxLayout, QInputDialog, QPushButton, \
     QShortcut, QVBoxLayout
 
 from ..puddleobjects import (PuddleConfig, ListBox,
@@ -77,7 +77,7 @@ class SettingsWin(QFrame):
         connect = lambda c, signal, s: getattr(c, signal).connect(s)
         self.setFrameStyle(QFrame.Box)
         self.listbox = ListBox()
-        self.listbox.setSelectionMode(self.listbox.ExtendedSelection)
+        self.listbox.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
         buttons = ListButtons()
 
         self.listbox.addItems(status['patterns'])

--- a/puddlestuff/mainwin/patterncombo.py
+++ b/puddlestuff/mainwin/patterncombo.py
@@ -87,7 +87,7 @@ class SettingsWin(QFrame):
 
         vbox = QVBoxLayout()
         sortlistbox = QPushButton(translate("Pattern Settings", '&Sort'))
-        self._sortOrder = Qt.AscendingOrder
+        self._sortOrder = Qt.SortOrder.AscendingOrder
         connect(sortlistbox, 'clicked', self._sortListBox)
         vbox.addWidget(sortlistbox)
         vbox.addLayout(buttons)
@@ -103,12 +103,12 @@ class SettingsWin(QFrame):
         connect(self.listbox, 'itemDoubleClicked', self._doubleClicked)
 
     def _sortListBox(self):
-        if self._sortOrder == Qt.AscendingOrder:
-            self.listbox.sortItems(Qt.DescendingOrder)
-            self._sortOrder = Qt.DescendingOrder
+        if self._sortOrder == Qt.SortOrder.AscendingOrder:
+            self.listbox.sortItems(Qt.SortOrder.DescendingOrder)
+            self._sortOrder = Qt.SortOrder.DescendingOrder
         else:
-            self.listbox.sortItems(Qt.AscendingOrder)
-            self._sortOrder = Qt.AscendingOrder
+            self.listbox.sortItems(Qt.SortOrder.AscendingOrder)
+            self._sortOrder = Qt.SortOrder.AscendingOrder
 
     def saveSettings(self):
         patterns = [str(self.listbox.item(row).text()) for row in range(self.listbox.count())]

--- a/puddlestuff/mainwin/patterncombo.py
+++ b/puddlestuff/mainwin/patterncombo.py
@@ -75,7 +75,7 @@ class SettingsWin(QFrame):
         QFrame.__init__(self, parent)
         self.title = translate('Settings', "Patterns")
         connect = lambda c, signal, s: getattr(c, signal).connect(s)
-        self.setFrameStyle(QFrame.Box)
+        self.setFrameStyle(QFrame.Shape.Box)
         self.listbox = ListBox()
         self.listbox.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
         buttons = ListButtons()

--- a/puddlestuff/mainwin/patterncombo.py
+++ b/puddlestuff/mainwin/patterncombo.py
@@ -40,7 +40,7 @@ class PatternCombo(QComboBox):
 
         shortcut = QShortcut(self)
         shortcut.setKey('F8')
-        shortcut.setContext(Qt.ApplicationShortcut)
+        shortcut.setContext(Qt.ShortcutContext.ApplicationShortcut)
 
         def set_focus():
             if self.hasFocus():

--- a/puddlestuff/mainwin/storedtags.py
+++ b/puddlestuff/mainwin/storedtags.py
@@ -111,7 +111,7 @@ class StoredTags(QScrollArea):
                     grid.addWidget(t_label, offset - 1, 0)
                     for row, (tag, value) in enumerate(values):
                         field = QLabel('%s:' % tag)
-                        field.setAlignment(Qt.AlignTop | Qt.AlignLeft)
+                        field.setAlignment(Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignLeft)
                         grid.addWidget(field, row + offset, 0)
                         vlabel = QLabel(value)
                         grid.addWidget(vlabel, row + offset, 1)

--- a/puddlestuff/mainwin/tagpanel.py
+++ b/puddlestuff/mainwin/tagpanel.py
@@ -134,7 +134,7 @@ class FrameCombo(QGroupBox):
             edit = QLineEdit()
             combo.setLineEdit(edit)
             completer = combo.completer()
-            completer.setCaseSensitivity(Qt.CaseSensitive)
+            completer.setCaseSensitivity(Qt.CaseSensitivity.CaseSensitive)
             completer.setCompletionMode(QCompleter.UnfilteredPopupCompletion)
 
     def disableCombos(self):
@@ -149,7 +149,7 @@ class FrameCombo(QGroupBox):
             edit = QLineEdit()
             combo.setLineEdit(edit)
             completer = combo.completer()
-            completer.setCaseSensitivity(Qt.CaseSensitive)
+            completer.setCaseSensitivity(Qt.CaseSensitivity.CaseSensitive)
             completer.setCompletionMode(QCompleter.UnfilteredPopupCompletion)
             edit.textEdited.connect(func)
             combo.currentIndexChanged.connect(func)
@@ -318,7 +318,7 @@ class FrameCombo(QGroupBox):
                 self.combos[tagval].completer().setCompletionMode(
                     QCompleter.UnfilteredPopupCompletion)
                 self.combos[tagval].completer().setCaseSensitivity(
-                    Qt.CaseSensitive)
+                    Qt.CaseSensitivity.CaseSensitive)
                 self.labels[tagval].setBuddy(self.combos[tagval])
                 labelbox.addWidget(self.labels[tagval])
                 widgetbox.addWidget(self.combos[tagval])

--- a/puddlestuff/mainwin/tagpanel.py
+++ b/puddlestuff/mainwin/tagpanel.py
@@ -332,7 +332,7 @@ class FrameCombo(QGroupBox):
         self.setMaximumHeight(self.sizeHint().height())
 
     def eventFilter(self, obj, event):
-        if isinstance(obj, QComboBox) and event.type() == QEvent.FocusOut:
+        if isinstance(obj, QComboBox) and event.type() == QEvent.Type.FocusOut:
             return False
         return QGroupBox.eventFilter(self, obj, event)
 

--- a/puddlestuff/mainwin/tagpanel.py
+++ b/puddlestuff/mainwin/tagpanel.py
@@ -313,7 +313,7 @@ class FrameCombo(QGroupBox):
                 tagval = tag[1]
                 self.labels[tagval] = QLabel(tag[0])
                 self.combos[tagval] = QComboBox(self)
-                self.combos[tagval].setInsertPolicy(QComboBox.NoInsert)
+                self.combos[tagval].setInsertPolicy(QComboBox.InsertPolicy.NoInsert)
                 self.combos[tagval].setEditable(True)
                 self.combos[tagval].completer().setCompletionMode(
                     QCompleter.UnfilteredPopupCompletion)

--- a/puddlestuff/mainwin/tagpanel.py
+++ b/puddlestuff/mainwin/tagpanel.py
@@ -135,7 +135,7 @@ class FrameCombo(QGroupBox):
             combo.setLineEdit(edit)
             completer = combo.completer()
             completer.setCaseSensitivity(Qt.CaseSensitivity.CaseSensitive)
-            completer.setCompletionMode(QCompleter.UnfilteredPopupCompletion)
+            completer.setCompletionMode(QCompleter.CompletionMode.UnfilteredPopupCompletion)
 
     def disableCombos(self):
         for z in self.combos:
@@ -150,7 +150,7 @@ class FrameCombo(QGroupBox):
             combo.setLineEdit(edit)
             completer = combo.completer()
             completer.setCaseSensitivity(Qt.CaseSensitivity.CaseSensitive)
-            completer.setCompletionMode(QCompleter.UnfilteredPopupCompletion)
+            completer.setCompletionMode(QCompleter.CompletionMode.UnfilteredPopupCompletion)
             edit.textEdited.connect(func)
             combo.currentIndexChanged.connect(func)
             self.__indexFuncs.append((combo, func))
@@ -316,7 +316,7 @@ class FrameCombo(QGroupBox):
                 self.combos[tagval].setInsertPolicy(QComboBox.InsertPolicy.NoInsert)
                 self.combos[tagval].setEditable(True)
                 self.combos[tagval].completer().setCompletionMode(
-                    QCompleter.UnfilteredPopupCompletion)
+                    QCompleter.CompletionMode.UnfilteredPopupCompletion)
                 self.combos[tagval].completer().setCaseSensitivity(
                     Qt.CaseSensitivity.CaseSensitive)
                 self.labels[tagval].setBuddy(self.combos[tagval])

--- a/puddlestuff/mainwin/tagpanel.py
+++ b/puddlestuff/mainwin/tagpanel.py
@@ -431,7 +431,7 @@ class PuddleTable(QTableWidget):
 
 
 TABLEWIDGETBG = QTableWidgetItem().background()
-RED = QBrush(Qt.red)
+RED = QBrush(Qt.GlobalColor.red)
 
 TITLE = translate("Defaults", 'Title')
 FIELD = translate("Defaults", 'Field')

--- a/puddlestuff/mainwin/tagpanel.py
+++ b/puddlestuff/mainwin/tagpanel.py
@@ -74,9 +74,9 @@ class Combo(QComboBox):
             return super(Combo, self).focusOutEvent(event)
         curtext = self.currentText()
         index = self.findText(curtext,
-                              Qt.MatchExactly | Qt.MatchFixedString | Qt.MatchCaseSensitive)
+                              Qt.MatchFlag.MatchExactly | Qt.MatchFlag.MatchFixedString | Qt.MatchFlag.MatchCaseSensitive)
         if index == -1:
-            index = self.findText(curtext, Qt.MatchExactly | Qt.MatchFixedString)
+            index = self.findText(curtext, Qt.MatchFlag.MatchExactly | Qt.MatchFlag.MatchFixedString)
         if index > 1:
             if curtext == self.itemText(index):
                 self.removeItem(index)

--- a/puddlestuff/musiclib.py
+++ b/puddlestuff/musiclib.py
@@ -292,7 +292,7 @@ class LibraryTree(QTreeWidget):
         self.__searchResults = []
 
         self.setHeaderLabels([translate('MusicLib', "Library Artists")])
-        self.setSelectionMode(QAbstractItemView.ExtendedSelection)
+        self.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
         self.setSortingEnabled(True)
         self.sortItems(0, Qt.SortOrder.AscendingOrder)
 

--- a/puddlestuff/musiclib.py
+++ b/puddlestuff/musiclib.py
@@ -166,7 +166,7 @@ class LibChooseDialog(QDialog):
         okcancel.cancel.connect(self.close)
 
         self.stack = QStackedWidget()
-        self.stack.setFrameStyle(QFrame.Box)
+        self.stack.setFrameStyle(QFrame.Shape.Box)
         list(map(self.stack.addWidget, self.stackwidgets))
 
         hbox = QHBoxLayout()

--- a/puddlestuff/musiclib.py
+++ b/puddlestuff/musiclib.py
@@ -420,7 +420,7 @@ class LibraryTree(QTreeWidget):
         take_item = self.takeTopLevelItem
 
         for artist in data:
-            artist_item = self.findItems(artist, Qt.MatchExactly)[0]
+            artist_item = self.findItems(artist, Qt.MatchFlag.MatchExactly)[0]
             if artist in lib_artists:
                 albums = get_albums(artist)
                 remove = artist_item.removeChild
@@ -445,7 +445,7 @@ class LibraryTree(QTreeWidget):
 
         newartists = []
         for artist in set(artists):
-            artist_item = self.findItems(artist, Qt.MatchExactly)
+            artist_item = self.findItems(artist, Qt.MatchFlag.MatchExactly)
             if artist_item:
                 artist_item = artist_item[0]
                 albums = get_albums(artist)

--- a/puddlestuff/musiclib.py
+++ b/puddlestuff/musiclib.py
@@ -296,8 +296,8 @@ class LibraryTree(QTreeWidget):
         self.setSortingEnabled(True)
         self.sortItems(0, Qt.SortOrder.AscendingOrder)
 
-        self.CLOSED_ICON = self.style().standardIcon(QStyle.SP_DirClosedIcon)
-        self.OPEN_ICON = self.style().standardIcon(QStyle.SP_DirOpenIcon)
+        self.CLOSED_ICON = self.style().standardIcon(QStyle.StandardPixmap.SP_DirClosedIcon)
+        self.OPEN_ICON = self.style().standardIcon(QStyle.StandardPixmap.SP_DirOpenIcon)
 
         self.itemCollapsed.connect(
             lambda item: item.setIcon(0, self.CLOSED_ICON))

--- a/puddlestuff/musiclib.py
+++ b/puddlestuff/musiclib.py
@@ -294,7 +294,7 @@ class LibraryTree(QTreeWidget):
         self.setHeaderLabels([translate('MusicLib', "Library Artists")])
         self.setSelectionMode(QAbstractItemView.ExtendedSelection)
         self.setSortingEnabled(True)
-        self.sortItems(0, Qt.AscendingOrder)
+        self.sortItems(0, Qt.SortOrder.AscendingOrder)
 
         self.CLOSED_ICON = self.style().standardIcon(QStyle.SP_DirClosedIcon)
         self.OPEN_ICON = self.style().standardIcon(QStyle.SP_DirOpenIcon)

--- a/puddlestuff/pluginloader.py
+++ b/puddlestuff/pluginloader.py
@@ -138,9 +138,9 @@ class PluginConfig(QDialog):
             item = QListWidgetItem()
             item.setText(plugin[NAME])
             if plugin[MODULE_NAME] in to_load:
-                item.setCheckState(Qt.Checked)
+                item.setCheckState(Qt.CheckState.Checked)
             else:
-                item.setCheckState(Qt.Unchecked)
+                item.setCheckState(Qt.CheckState.Unchecked)
             item.plugin = plugin
             self._listbox.addItem(item)
 
@@ -151,7 +151,7 @@ class PluginConfig(QDialog):
         to_load = []
         for row in range(self._listbox.count()):
             item = self._listbox.item(row)
-            if item.checkState() == Qt.Checked:
+            if item.checkState() == Qt.CheckState.Checked:
                 to_load.append(item.plugin[MODULE_NAME])
         return to_load
 

--- a/puddlestuff/pluginloader.py
+++ b/puddlestuff/pluginloader.py
@@ -93,7 +93,7 @@ def load_plugins(plugins=None, parent=None):
 class InfoWidget(QLabel):
     def __init__(self, info=None, parent=None):
         super(InfoWidget, self).__init__(parent)
-        self.setAlignment(Qt.AlignLeft | Qt.AlignTop)
+        self.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
         self.setWordWrap(True)
         if info:
             self.changeInfo(info)

--- a/puddlestuff/plugins/view_all_fields/__init__.py
+++ b/puddlestuff/plugins/view_all_fields/__init__.py
@@ -95,7 +95,7 @@ class ButtonsAndList(QFrame):
 
         vbox = QVBoxLayout()
         sortlistbox = QPushButton(translate("Defaults", '&Sort'))
-        self._sortOrder = Qt.AscendingOrder
+        self._sortOrder = Qt.SortOrder.AscendingOrder
         connect(sortlistbox, 'clicked', self._sortListBox)
         vbox.addWidget(sortlistbox)
         vbox.addLayout(buttons)
@@ -125,12 +125,12 @@ class ButtonsAndList(QFrame):
         self.editItem()
 
     def _sortListBox(self):
-        if self._sortOrder == Qt.AscendingOrder:
-            self.listbox.sortItems(Qt.DescendingOrder)
-            self._sortOrder = Qt.DescendingOrder
+        if self._sortOrder == Qt.SortOrder.AscendingOrder:
+            self.listbox.sortItems(Qt.SortOrder.DescendingOrder)
+            self._sortOrder = Qt.SortOrder.DescendingOrder
         else:
-            self.listbox.sortItems(Qt.AscendingOrder)
-            self._sortOrder = Qt.AscendingOrder
+            self.listbox.sortItems(Qt.SortOrder.AscendingOrder)
+            self._sortOrder = Qt.SortOrder.AscendingOrder
 
     def addItem(self):
         l = self.listbox.item

--- a/puddlestuff/plugins/view_all_fields/__init__.py
+++ b/puddlestuff/plugins/view_all_fields/__init__.py
@@ -85,7 +85,7 @@ class ButtonsAndList(QFrame):
         QFrame.__init__(self, parent)
         self.title = title
         connect = lambda c, signal, s: getattr(c, signal).connect(s)
-        self.setFrameStyle(QFrame.Box)
+        self.setFrameStyle(QFrame.Shape.Box)
         self.listbox = ListBox()
         self.listbox.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
         buttons = ListButtons()

--- a/puddlestuff/plugins/view_all_fields/__init__.py
+++ b/puddlestuff/plugins/view_all_fields/__init__.py
@@ -1,7 +1,7 @@
 import os
 
 from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QAction, QApplication, QFrame, QHBoxLayout, QInputDialog, QLabel, \
+from PyQt5.QtWidgets import QAbstractItemView, QAction, QApplication, QFrame, QHBoxLayout, QInputDialog, QLabel, \
     QPushButton, QVBoxLayout
 
 from ...puddlesettings import add_config_widget
@@ -87,7 +87,7 @@ class ButtonsAndList(QFrame):
         connect = lambda c, signal, s: getattr(c, signal).connect(s)
         self.setFrameStyle(QFrame.Box)
         self.listbox = ListBox()
-        self.listbox.setSelectionMode(self.listbox.ExtendedSelection)
+        self.listbox.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
         buttons = ListButtons()
 
         hbox = QHBoxLayout()

--- a/puddlestuff/plugins/view_all_fields/__init__.py
+++ b/puddlestuff/plugins/view_all_fields/__init__.py
@@ -48,7 +48,7 @@ def show_all_fields(fields=None):
     data = [(k, k) for k in fields + sorted(keys, key=natsort_case_key)]
     tb = status['table']
     tb.model().setHeader(data)
-    hd = TableHeader(Qt.Horizontal, data)
+    hd = TableHeader(Qt.Orientation.Horizontal, data)
     tb.setHorizontalHeader(hd)
     hd.show()
 

--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -515,14 +515,14 @@ def errormsg(parent, msg, maximum):
     if maximum > 1:
         mb = QMessageBox(QMessageBox.Icon.Warning, translate("Defaults", 'Error'),
                          msg + translate("Defaults", "<br /> Do you want to continue?"),
-                         QMessageBox.Yes | QMessageBox.No | QMessageBox.YesToAll,
+                         QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No | QMessageBox.StandardButton.YesToAll,
                          parent)
-        mb.setDefaultButton(QMessageBox.Yes)
-        mb.setEscapeButton(QMessageBox.No)
+        mb.setDefaultButton(QMessageBox.StandardButton.Yes)
+        mb.setEscapeButton(QMessageBox.StandardButton.No)
         ret = mb.exec_()
-        if ret == QMessageBox.No:
+        if ret == QMessageBox.StandardButton.No:
             return False
-        elif ret == QMessageBox.YesToAll:
+        elif ret == QMessageBox.StandardButton.YesToAll:
             return True
     else:
         singleerror(parent, msg)

--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -829,7 +829,7 @@ def load_actions():
 
 def open_resourcefile(filename):
     f = QFile(filename)
-    f.open(QIODevice.ReadOnly)
+    f.open(QIODevice.OpenModeFlag.ReadOnly)
     return StringIO(str(f.readAll().data(), encoding='utf-8'))
 
 
@@ -1843,7 +1843,7 @@ class PicWidget(QWidget):
         if not image.isNull():
             ba = QByteArray()
             data = QBuffer(ba)
-            data.open(QIODevice.WriteOnly)
+            data.open(QIODevice.OpenModeFlag.WriteOnly)
             # TODO: Don't transform to JPG
             image.save(data, "JPG")
             data = bytes(data.data())
@@ -2070,7 +2070,7 @@ class PicWidget(QWidget):
             if filename.startswith(":/"):
                 ba = QByteArray()
                 data = QBuffer(ba)
-                data.open(QIODevice.WriteOnly)
+                data.open(QIODevice.OpenModeFlag.WriteOnly)
                 image.save(data, "JPG")
                 data = str(data.data())
             else:

--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -1518,7 +1518,7 @@ class ArtworkLabel(QGraphicsView):
 
     def mousePressEvent(self, event):
         super(ArtworkLabel, self).mousePressEvent(event)
-        if event.buttons() == Qt.LeftButton:
+        if event.buttons() == Qt.MouseButton.LeftButton:
             self.clicked.emit()
 
     def resizeEvent(self, event=None):

--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -1591,7 +1591,7 @@ class PicWidget(QWidget):
         self.filePattern = 'folder.jpg'
 
         self.label = ArtworkLabel()
-        self.label.setFrameStyle(QFrame.Box)
+        self.label.setFrameStyle(QFrame.Shape.Box)
 
         self.label.setMinimumSize(200, 170)
         if buttons:
@@ -1971,7 +1971,7 @@ class PicWidget(QWidget):
         self._image_type.blockSignals(False)
         self._currentImage = num
         self.context = str(self._contextFormat.arg(str(num + 1)).arg(str(len(self.images))))
-        self.label.setFrameStyle(QFrame.NoFrame)
+        self.label.setFrameStyle(QFrame.Shape.NoFrame)
         self.enableButtons()
         # self.resizeEvent()
 
@@ -2023,7 +2023,7 @@ class PicWidget(QWidget):
                                      translate("Artwork", 'Writing to <b>%1</b> failed.').arg(filename))
 
     def setNone(self):
-        self.label.setFrameStyle(QFrame.Box)
+        self.label.setFrameStyle(QFrame.Shape.Box)
         self.label.setPixmap(QPixmap())
         self._image_size.setText("")
         self.pixmap = None

--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -1421,8 +1421,8 @@ class OKCancel(QHBoxLayout):
         # self.addStretch()
         dbox = QDialogButtonBox()
 
-        self.okButton = dbox.addButton(dbox.Ok)
-        self.cancelButton = dbox.addButton(dbox.Cancel)
+        self.okButton = dbox.addButton(QDialogButtonBox.StandardButton.Ok)
+        self.cancelButton = dbox.addButton(QDialogButtonBox.StandardButton.Cancel)
         self.addStretch()
         self.addWidget(dbox)
 

--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -1452,7 +1452,7 @@ class LongInfoMessage(QDialog):
 
         text = QTextEdit()
         text.setReadOnly(True)
-        # text.setWordWrapMode(QTextOption.NoWrap)
+        # text.setWordWrapMode(QTextOption.WrapMode.NoWrap)
         text.setHtml(html)
 
         okcancel = OKCancel()

--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -50,13 +50,13 @@ SD_PATTERNS = [
 ]
 
 mod_keys = {
-    Qt.ShiftModifier: 'Shift',
-    Qt.MetaModifier: 'Meta',
-    Qt.AltModifier: 'Alt',
-    Qt.ControlModifier: 'Ctrl',
-    Qt.NoModifier: '',
-    Qt.KeypadModifier: '',
-    Qt.GroupSwitchModifier: '', }
+    Qt.KeyboardModifier.ShiftModifier: 'Shift',
+    Qt.KeyboardModifier.MetaModifier: 'Meta',
+    Qt.KeyboardModifier.AltModifier: 'Alt',
+    Qt.KeyboardModifier.ControlModifier: 'Ctrl',
+    Qt.KeyboardModifier.NoModifier: '',
+    Qt.KeyboardModifier.KeypadModifier: '',
+    Qt.KeyboardModifier.GroupSwitchModifier: '', }
 
 
 def keycmp(modifier):

--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -1486,7 +1486,7 @@ class ArtworkLabel(QGraphicsView):
 
         self._svg = QGraphicsSvgItem()
         self._pixmap = QGraphicsPixmapItem()
-        self._pixmap.setTransformationMode(Qt.SmoothTransformation)
+        self._pixmap.setTransformationMode(Qt.TransformationMode.SmoothTransformation)
         self._scene = QGraphicsScene()
         self._scene.addItem(self._svg)
         self._scene.addItem(self._pixmap)

--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -2355,7 +2355,7 @@ class PuddleHeader(QHeaderView):
             super(PuddleHeader, self).__init__()
 
         self.setSortIndicatorShown(True)
-        self.setSortIndicator(0, Qt.AscendingOrder)
+        self.setSortIndicator(0, Qt.SortOrder.AscendingOrder)
         self.setSectionsMovable(True)
         self.setSectionsClickable(True)
 

--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -109,7 +109,7 @@ for i in range(1, len(mod_keys)):
             mod = mod | key
         modifiers[int(mod)] = '+'.join(mod_keys[key] for key in sorted(keys, key=keycmp) if mod_keys[key])
 
-mod_keys = set((Qt.Key_Shift, Qt.Key_Control, Qt.Key_Meta, Qt.Key_Alt))
+mod_keys = set((Qt.Key.Key_Shift, Qt.Key.Key_Control, Qt.Key.Key_Meta, Qt.Key.Key_Alt))
 
 imagetypes = [
     (translate('Cover Type', 'Other'), translate("Cover Type", 'O')),

--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -2348,7 +2348,7 @@ class PuddleDock(QDockWidget):
 
 
 class PuddleHeader(QHeaderView):
-    def __init__(self, orientation=Qt.Horizontal, parent=None):
+    def __init__(self, orientation=Qt.Orientation.Horizontal, parent=None):
         if parent:
             super(PuddleHeader, self).__init__(orientation, parent)
         else:

--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -60,13 +60,13 @@ mod_keys = {
 
 
 def keycmp(modifier):
-    if modifier == Qt.CTRL:
+    if modifier == Qt.Modifier.CTRL:
         return 4
-    elif modifier == Qt.SHIFT:
+    elif modifier == Qt.Modifier.SHIFT:
         return 3
-    elif modifier == Qt.ALT:
+    elif modifier == Qt.Modifier.ALT:
         return 2
-    elif modifier == Qt.META:
+    elif modifier == Qt.Modifier.META:
         return 1
     else:
         return 0

--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -24,7 +24,7 @@ from PyQt5.QtGui import QIcon, QBrush, QPixmap, QImage, \
 from PyQt5.QtSvg import QGraphicsSvgItem, QSvgRenderer
 from PyQt5.QtWidgets import QAbstractItemView, QAction, QApplication, QComboBox, QDesktopWidget, QDialog, QDialogButtonBox, \
     QDockWidget, QFileDialog, QFrame, QGraphicsPixmapItem, QGraphicsScene, QGraphicsView, QGridLayout, QHBoxLayout, \
-    QHeaderView, QLabel, QLineEdit, QListWidget, QMenu, QMessageBox, QProgressBar, QPushButton, QSizePolicy, \
+    QHeaderView, QLabel, QLayout, QLineEdit, QListWidget, QMenu, QMessageBox, QProgressBar, QPushButton, QSizePolicy, \
     QTextEdit, QToolButton, QVBoxLayout, QWidget
 from configobj import ConfigObjError
 
@@ -1713,7 +1713,7 @@ class PicWidget(QWidget):
         hbox = QHBoxLayout()
         hbox.addLayout(vbox)
         hbox.addStrut(12)
-        hbox.setSizeConstraint(hbox.SetMinAndMaxSize)
+        hbox.setSizeConstraint(QLayout.SizeConstraint.SetMinAndMaxSize)
         self.setLayout(hbox)
 
         if buttons:

--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -281,7 +281,7 @@ class PuddleConfig(object):
 
 def _getSettings():
     filename = os.path.join(CONFIGDIR, 'windowsizes')
-    return QSettings(filename, QSettings.IniFormat)
+    return QSettings(filename, QSettings.Format.IniFormat)
 
 
 def savewinsize(name, dialog, settings=_getSettings()):

--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -22,7 +22,7 @@ from PyQt5.QtCore import QFile, QIODevice
 from PyQt5.QtGui import QIcon, QBrush, QPixmap, QImage, \
     QKeySequence
 from PyQt5.QtSvg import QGraphicsSvgItem, QSvgRenderer
-from PyQt5.QtWidgets import QAction, QApplication, QComboBox, QDesktopWidget, QDialog, QDialogButtonBox, \
+from PyQt5.QtWidgets import QAbstractItemView, QAction, QApplication, QComboBox, QDesktopWidget, QDialog, QDialogButtonBox, \
     QDockWidget, QFileDialog, QFrame, QGraphicsPixmapItem, QGraphicsScene, QGraphicsView, QGridLayout, QHBoxLayout, \
     QHeaderView, QLabel, QLineEdit, QListWidget, QMenu, QMessageBox, QProgressBar, QPushButton, QSizePolicy, \
     QTextEdit, QToolButton, QVBoxLayout, QWidget
@@ -1130,7 +1130,7 @@ class ListBox(QListWidget):
         QListWidget.__init__(self, parent)
         self.yourlist = None
         self.editButton = None
-        self.setSelectionMode(self.ExtendedSelection)
+        self.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
 
     def items(self):
         return list(map(self.item, range(self.count())))

--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -1529,7 +1529,7 @@ class ArtworkLabel(QGraphicsView):
         else:
             item = self._pixmap
         self.setSceneRect(item.boundingRect())
-        self.fitInView(item, Qt.KeepAspectRatio)
+        self.fitInView(item, Qt.AspectRatioMode.KeepAspectRatio)
 
     def setPixmap(self, pixmap, data=None):
         if isinstance(pixmap, str):

--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -1598,12 +1598,12 @@ class PicWidget(QWidget):
             self.label.setMaximumSize(200, 170)
         self._itags = []
 
-        self.label.setAlignment(Qt.AlignCenter)
+        self.label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.label.newImages.connect(
             lambda filenames: self.addImages(self.loadPics(*filenames)))
 
         self._image_size = QLabel()
-        self._image_size.setAlignment(Qt.AlignHCenter)
+        self._image_size.setAlignment(Qt.AlignmentFlag.AlignHCenter)
 
         self._image_desc = QLineEdit(self)
 
@@ -1695,7 +1695,7 @@ class PicWidget(QWidget):
         if not buttons:
             h.addLayout(movebuttons)
             context_box = QHBoxLayout()
-            context_box.setAlignment(Qt.AlignHCenter)
+            context_box.setAlignment(Qt.AlignmentFlag.AlignHCenter)
             context_box.addWidget(self._contextlabel)
             vbox.addLayout(context_box)
         h.addStretch()
@@ -1706,7 +1706,7 @@ class PicWidget(QWidget):
         if buttons:
             vbox.addLayout(movebuttons)
         vbox.addStretch()
-        vbox.setAlignment(Qt.AlignCenter)
+        vbox.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
         self.label.clicked.connect(self.maxImage)
 
@@ -2190,7 +2190,7 @@ class ProgressWin(QDialog):
         self.pbar.setRange(0, maximum)
 
         self.label = QLabel()
-        self.label.setAlignment(Qt.AlignHCenter)
+        self.label.setAlignment(Qt.AlignmentFlag.AlignHCenter)
 
         if maximum <= 0:
             self.pbar.setTextVisible(False)

--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -1734,7 +1734,7 @@ class PicWidget(QWidget):
             hbox.addLayout(listbuttons)
 
         else:
-            self.label.setContextMenuPolicy(Qt.ActionsContextMenu)
+            self.label.setContextMenuPolicy(Qt.ContextMenuPolicy.ActionsContextMenu)
             self.savepic = QAction(translate("Artwork", "&Save cover to file"), self)
             self.label.addAction(self.savepic)
 

--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -2266,7 +2266,7 @@ class PuddleCombo(QWidget):
         hbox = QHBoxLayout()
         hbox.setContentsMargins(0, 0, 0, 0)
         self.combo = QComboBox()
-        self.combo.setSizeAdjustPolicy(QComboBox.AdjustToMinimumContentsLength)
+        self.combo.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToMinimumContentsLength)
 
         self.remove = QToolButton()
         self.remove.setIcon(get_icon('list-remove', ':/remove.png'))

--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -1582,7 +1582,7 @@ class PicWidget(QWidget):
         self._contextFormat = translate("Artwork Context", '%1/%2')
 
         QWidget.__init__(self, parent)
-        self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        self.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         self.sizePolicy().setVerticalStretch(0)
         self.sizePolicy().setHorizontalStretch(3)
 

--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -513,7 +513,7 @@ def errormsg(parent, msg, maximum):
         False if No.
         None if just yes."""
     if maximum > 1:
-        mb = QMessageBox(QMessageBox.Warning, translate("Defaults", 'Error'),
+        mb = QMessageBox(QMessageBox.Icon.Warning, translate("Defaults", 'Error'),
                          msg + translate("Defaults", "<br /> Do you want to continue?"),
                          QMessageBox.Yes | QMessageBox.No | QMessageBox.YesToAll,
                          parent)

--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -1272,10 +1272,10 @@ class ListButtons(QVBoxLayout):
         self.removeButton.setToolTip(translate("List Buttons", 'Remove'))
         self.removeButton.setShortcut('Delete')
         self.moveupButton = QToolButton()
-        self.moveupButton.setArrowType(Qt.UpArrow)
+        self.moveupButton.setArrowType(Qt.ArrowType.UpArrow)
         self.moveupButton.setToolTip(translate("List Buttons", 'Move Up'))
         self.movedownButton = QToolButton()
-        self.movedownButton.setArrowType(Qt.DownArrow)
+        self.movedownButton.setArrowType(Qt.ArrowType.DownArrow)
         self.movedownButton.setToolTip(translate("List Buttons", 'Move Down'))
         self.editButton = QToolButton()
         self.editButton.setIcon(get_icon('document-edit', ':/edit.png'))
@@ -1654,9 +1654,9 @@ class PicWidget(QWidget):
         self.readonly = readonly
 
         self.next = QToolButton()
-        self.next.setArrowType(Qt.RightArrow)
+        self.next.setArrowType(Qt.ArrowType.RightArrow)
         self.prev = QToolButton()
-        self.prev.setArrowType(Qt.LeftArrow)
+        self.prev.setArrowType(Qt.ArrowType.LeftArrow)
         self.next.clicked.connect(self.nextImage)
         self.prev.clicked.connect(self.prevImage)
 
@@ -1670,8 +1670,8 @@ class PicWidget(QWidget):
             movebuttons.addWidget(self._contextlabel)
             movebuttons.addStretch()
         else:
-            self.next.setArrowType(Qt.UpArrow)
-            self.prev.setArrowType(Qt.DownArrow)
+            self.next.setArrowType(Qt.ArrowType.UpArrow)
+            self.prev.setArrowType(Qt.ArrowType.DownArrow)
             movebuttons = QVBoxLayout()
             movebuttons.addStretch()
             movebuttons.addWidget(self.next)

--- a/puddlestuff/puddlesettings.py
+++ b/puddlestuff/puddlesettings.py
@@ -506,8 +506,8 @@ class ListModel(QAbstractListModel):
 
     def flags(self, index):
         if not index.isValid():
-            return Qt.ItemIsEnabled
-        return Qt.ItemFlags(QAbstractListModel.flags(self, index))
+            return Qt.ItemFlag.ItemIsEnabled
+        return Qt.ItemFlag(QAbstractListModel.flags(self, index))
 
 
 class SettingsList(QListView):
@@ -527,7 +527,7 @@ class StatusWidgetItem(QTableWidgetItem):
     def __init__(self, text, color):
         QTableWidgetItem.__init__(self, text)
         self.setBackground(QBrush(color))
-        self.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled)
+        self.setFlags(Qt.ItemFlag.ItemIsSelectable | Qt.ItemFlag.ItemIsEnabled)
 
 
 class ColorEdit(QWidget):

--- a/puddlestuff/puddlesettings.py
+++ b/puddlestuff/puddlesettings.py
@@ -480,8 +480,8 @@ class ListModel(QAbstractListModel):
     def headerData(self, section, orientation, role=Qt.DisplayRole):
         if role == Qt.TextAlignmentRole:
             if orientation == Qt.Horizontal:
-                return int(Qt.AlignLeft | Qt.AlignVCenter)
-            return int(Qt.AlignRight | Qt.AlignVCenter)
+                return int(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
+            return int(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
         if role != Qt.DisplayRole:
             return None
         if orientation == Qt.Horizontal:

--- a/puddlestuff/puddlesettings.py
+++ b/puddlestuff/puddlesettings.py
@@ -141,7 +141,7 @@ class GeneralSettings(QWidget):
         self._lang_combo.addItems(list(get_languages([TRANSDIR])))
 
         if lang != 'auto':
-            i = self._lang_combo.findText(lang, Qt.MatchFixedString)
+            i = self._lang_combo.findText(lang, Qt.MatchFlag.MatchFixedString)
             if i > 0:
                 self._lang_combo.setCurrentIndex(i)
 

--- a/puddlestuff/puddlesettings.py
+++ b/puddlestuff/puddlesettings.py
@@ -479,12 +479,12 @@ class ListModel(QAbstractListModel):
 
     def headerData(self, section, orientation, role=Qt.ItemDataRole.DisplayRole):
         if role == Qt.ItemDataRole.TextAlignmentRole:
-            if orientation == Qt.Horizontal:
+            if orientation == Qt.Orientation.Horizontal:
                 return int(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
             return int(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
         if role != Qt.ItemDataRole.DisplayRole:
             return None
-        if orientation == Qt.Horizontal:
+        if orientation == Qt.Orientation.Horizontal:
             return self.headerdata[section]
         return int(section + 1)
 

--- a/puddlestuff/puddlesettings.py
+++ b/puddlestuff/puddlesettings.py
@@ -477,21 +477,21 @@ class ListModel(QAbstractListModel):
         QAbstractListModel.__init__(self)
         self.options = options
 
-    def headerData(self, section, orientation, role=Qt.DisplayRole):
-        if role == Qt.TextAlignmentRole:
+    def headerData(self, section, orientation, role=Qt.ItemDataRole.DisplayRole):
+        if role == Qt.ItemDataRole.TextAlignmentRole:
             if orientation == Qt.Horizontal:
                 return int(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
             return int(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
-        if role != Qt.DisplayRole:
+        if role != Qt.ItemDataRole.DisplayRole:
             return None
         if orientation == Qt.Horizontal:
             return self.headerdata[section]
         return int(section + 1)
 
-    def data(self, index, role=Qt.DisplayRole):
+    def data(self, index, role=Qt.ItemDataRole.DisplayRole):
         if not index.isValid() or not (0 <= index.row() < len(self.options)):
             return None
-        if (role == Qt.DisplayRole) or (role == Qt.ToolTipRole):
+        if (role == Qt.ItemDataRole.DisplayRole) or (role == Qt.ItemDataRole.ToolTipRole):
             try:
                 return str(self.options[index.row()][0])
             except IndexError:

--- a/puddlestuff/puddlesettings.py
+++ b/puddlestuff/puddlesettings.py
@@ -544,7 +544,7 @@ class ColorEdit(QWidget):
             *cparser.get('table', key, default, True))
 
         preview = get_color('preview_color', [192, 255, 192])
-        selection_default = QPalette().color(QPalette.Mid).getRgb()[:-1]
+        selection_default = QPalette().color(QPalette.ColorRole.Mid).getRgb()[:-1]
 
         selection = get_color('selected_color', selection_default)
 

--- a/puddlestuff/puddlesettings.py
+++ b/puddlestuff/puddlesettings.py
@@ -657,7 +657,7 @@ class SettingsDialog(QDialog):
         self.listbox.setModel(self.model)
 
         self.stack = QStackedWidget()
-        self.stack.setFrameStyle(QFrame.StyledPanel)
+        self.stack.setFrameStyle(QFrame.Shape.StyledPanel)
 
         self.grid = QGridLayout()
         self.grid.addWidget(self.listbox)

--- a/puddlestuff/puddlesettings.py
+++ b/puddlestuff/puddlesettings.py
@@ -672,7 +672,7 @@ class SettingsDialog(QDialog):
         index = self.model.index(0, 0)
         selection.select(index, index)
         self.listbox.setSelectionModel(self.selectionModel)
-        self.selectionModel.select(selection, QItemSelectionModel.Select)
+        self.selectionModel.select(selection, QItemSelectionModel.SelectionFlag.Select)
 
         self.okbuttons = OKCancel()
         self.okbuttons.okButton.setDefault(True)

--- a/puddlestuff/puddlesettings.py
+++ b/puddlestuff/puddlesettings.py
@@ -554,7 +554,7 @@ class ColorEdit(QWidget):
         label = QLabel(text)
 
         self.listbox = QTableWidget(0, 1, self)
-        self.listbox.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self.listbox.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
         header = self.listbox.horizontalHeader()
         self.listbox.setSortingEnabled(False)
         header.setVisible(True)

--- a/puddlestuff/puddlesettings.py
+++ b/puddlestuff/puddlesettings.py
@@ -72,16 +72,16 @@ class SettingsCheckBox(QCheckBox):
         self._text = text
 
     def _value(self):
-        if self.checkState() == Qt.Checked:
+        if self.checkState() == Qt.CheckState.Checked:
             return self._text, True
         else:
             return self._text, False
 
     def _setValue(self, value):
         if value:
-            self.setCheckState(Qt.Checked)
+            self.setCheckState(Qt.CheckState.Checked)
         else:
-            self.setCheckState(Qt.Unchecked)
+            self.setCheckState(Qt.CheckState.Unchecked)
 
     settingValue = property(_value, _setValue)
 
@@ -203,8 +203,8 @@ class Playlist(QWidget):
 
         def inttocheck(value):
             if value:
-                return Qt.Checked
-            return Qt.Unchecked
+                return Qt.CheckState.Checked
+            return Qt.CheckState.Unchecked
 
         cparser = PuddleConfig()
 
@@ -242,7 +242,7 @@ class Playlist(QWidget):
 
     def applySettings(self, control=None):
         def checktoint(checkbox):
-            if checkbox.checkState() == Qt.Checked:
+            if checkbox.checkState() == Qt.CheckState.Checked:
                 return 1
             else:
                 return 0

--- a/puddlestuff/puddletag.py
+++ b/puddlestuff/puddletag.py
@@ -500,7 +500,7 @@ class MainWin(QMainWindow):
     def createStatusBar(self):
         statusbar = self.statusBar()
         statuslabel = QLabel()
-        statuslabel.setFrameStyle(QFrame.NoFrame)
+        statuslabel.setFrameStyle(QFrame.Shape.NoFrame)
         statusbar.addPermanentWidget(statuslabel, 1)
         self._totalstats = QLabel('00 (00:00:00 | 00 MB)')
         self._selectedstats = QLabel('00 (00:00:00 | 00 MB)')

--- a/puddlestuff/puddletag.py
+++ b/puddlestuff/puddletag.py
@@ -451,10 +451,10 @@ class MainWin(QMainWindow):
         dirname = self._lastdir[0] if self._lastdir else QDir.homePath()
         filedlg = QFileDialog()
         filedlg.setFileMode(QFileDialog.FileMode.DirectoryOnly)
-        # not supported in PyQt5
-        # filedlg.setResolveSymlinks(False) 
-        filename = str(filedlg.getExistingDirectory(self,
-                                                    translate("Main Window", 'Import directory...'), dirname, QFileDialog.ShowDirsOnly|QFileDialog.DontUseNativeDialog))
+        filename = str(QFileDialog.getExistingDirectory(self,
+                                                        translate("Main Window", 'Import directory...'),
+                                                        dirname,
+                                                        QFileDialog.Option.ShowDirsOnly | QFileDialog.Option.DontUseNativeDialog | QFileDialog.Option.DontResolveSymlinks))
         return filename
 
     def appendDir(self, filename=None):

--- a/puddlestuff/puddletag.py
+++ b/puddlestuff/puddletag.py
@@ -450,7 +450,7 @@ class MainWin(QMainWindow):
     def _getDir(self):
         dirname = self._lastdir[0] if self._lastdir else QDir.homePath()
         filedlg = QFileDialog()
-        filedlg.setFileMode(filedlg.DirectoryOnly)
+        filedlg.setFileMode(QFileDialog.FileMode.DirectoryOnly)
         # not supported in PyQt5
         # filedlg.setResolveSymlinks(False) 
         filename = str(filedlg.getExistingDirectory(self,

--- a/puddlestuff/puddletag.py
+++ b/puddlestuff/puddletag.py
@@ -486,7 +486,7 @@ class MainWin(QMainWindow):
                     control.saveSettings()
 
         cparser = PuddleConfig()
-        settings = QSettings(constants.QT_CONFIG, QSettings.IniFormat)
+        settings = QSettings(constants.QT_CONFIG, QSettings.Format.IniFormat)
         if self._lastdir:
             cparser.set('main', 'lastfolder', self._lastdir[0])
         cparser.set("main", "maximized", self.isMaximized())
@@ -603,7 +603,7 @@ class MainWin(QMainWindow):
         connect_actions(scts, PuddleDock._controls)
 
         cparser = PuddleConfig()
-        settings = QSettings(constants.QT_CONFIG, QSettings.IniFormat)
+        settings = QSettings(constants.QT_CONFIG, QSettings.Format.IniFormat)
 
         gensettings = {}
         controls = list(PuddleDock._controls.values())

--- a/puddlestuff/releasewidget.py
+++ b/puddlestuff/releasewidget.py
@@ -353,9 +353,9 @@ class TreeModel(QtCore.QAbstractItemModel):
             item = index.internalPointer()
             if self.isTrack(item) and '#exact' in item.itemData:
                 if item.checked:
-                    return Qt.Checked
+                    return Qt.CheckState.Checked
                 else:
-                    return Qt.Unchecked
+                    return Qt.CheckState.Unchecked
         return None
 
     def fetchMore(self, index):

--- a/puddlestuff/releasewidget.py
+++ b/puddlestuff/releasewidget.py
@@ -94,7 +94,7 @@ class Header(QHeaderView):
     sortChanged = pyqtSignal(list, name='sortChanged')
 
     def __init__(self, parent=None):
-        QHeaderView.__init__(self, Qt.Horizontal, parent)
+        QHeaderView.__init__(self, Qt.Orientation.Horizontal, parent)
         self.setSectionsClickable(True)
         self.setStretchLastSection(True)
         self.setSortIndicatorShown(True)
@@ -417,7 +417,7 @@ class TreeModel(QtCore.QAbstractItemModel):
         return NORMALFLAG
 
     def headerData(self, section, orientation, role):
-        if orientation == QtCore.Qt.Horizontal and \
+        if orientation == Qt.Orientation.Horizontal and \
                 role == Qt.ItemDataRole.DisplayRole:
             ret = RETRIEVED_ALBUMS % ' / '.join(self.sortOrder)
 

--- a/puddlestuff/releasewidget.py
+++ b/puddlestuff/releasewidget.py
@@ -14,8 +14,8 @@ from .tagsources import RetrievalError
 from .translations import translate
 from .util import pprint_tag, to_string
 
-CHECKEDFLAG = Qt.ItemIsEnabled | Qt.ItemIsSelectable | Qt.ItemIsUserCheckable
-NORMALFLAG = Qt.ItemIsEnabled | Qt.ItemIsSelectable
+CHECKEDFLAG = Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable | Qt.ItemFlag.ItemIsUserCheckable
+NORMALFLAG = Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable
 
 RETRIEVED_ALBUMS = translate('WebDB', 'Retrieved Albums (sorted by %s)')
 

--- a/puddlestuff/releasewidget.py
+++ b/puddlestuff/releasewidget.py
@@ -5,7 +5,7 @@ from functools import partial
 
 from PyQt5 import QtCore
 from PyQt5.QtCore import QModelIndex, Qt, pyqtRemoveInputHook, pyqtSignal
-from PyQt5.QtWidgets import QAction, QApplication, QHeaderView, QMenu, QStyle, QTreeView, QWidget
+from PyQt5.QtWidgets import QAbstractItemView, QAction, QApplication, QHeaderView, QMenu, QStyle, QTreeView, QWidget
 
 from .findfunc import parsefunc
 from .puddleobjects import (PuddleThread,
@@ -542,7 +542,7 @@ class ReleaseWidget(QTreeView):
 
     def __init__(self, status, tagsource, parent=None):
         QTreeView.__init__(self, parent)
-        self.setSelectionMode(self.ExtendedSelection)
+        self.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
         self.setSortingEnabled(True)
         self.setExpandsOnDoubleClick(False)
         self._tagSource = tagsource

--- a/puddlestuff/releasewidget.py
+++ b/puddlestuff/releasewidget.py
@@ -98,7 +98,7 @@ class Header(QHeaderView):
         self.setSectionsClickable(True)
         self.setStretchLastSection(True)
         self.setSortIndicatorShown(True)
-        self.setSortIndicator(0, Qt.AscendingOrder)
+        self.setSortIndicator(0, Qt.SortOrder.AscendingOrder)
         self.sortOptions = [z.split(',') for z in
                             ['artist,album', 'album,artist', '__numtracks,album']]
 
@@ -521,9 +521,9 @@ class TreeModel(QtCore.QAbstractItemModel):
         if exact_matches:
             self.exactMatches.emit(exact_matches)
 
-    def sort(self, column=0, order=Qt.AscendingOrder):
+    def sort(self, column=0, order=Qt.SortOrder.AscendingOrder):
         self.beginResetModel()
-        if order == Qt.AscendingOrder:
+        if order == Qt.SortOrder.AscendingOrder:
             self.rootItem.sort(self.sortOrder)
         else:
             self.rootItem.sort(self.sortOrder, True)

--- a/puddlestuff/releasewidget.py
+++ b/puddlestuff/releasewidget.py
@@ -335,13 +335,13 @@ class TreeModel(QtCore.QAbstractItemModel):
         if not index.isValid():
             return None
 
-        if role == Qt.DisplayRole:
+        if role == Qt.ItemDataRole.DisplayRole:
             item = index.internalPointer()
             return item.data(index.column())
-        elif role == Qt.ToolTipRole:
+        elif role == Qt.ItemDataRole.ToolTipRole:
             item = index.internalPointer()
             return tooltip(item.itemData, self.mapping)
-        elif role == Qt.DecorationRole:
+        elif role == Qt.ItemDataRole.DecorationRole:
             item = index.internalPointer()
             if self.isTrack(item):
                 return None
@@ -349,7 +349,7 @@ class TreeModel(QtCore.QAbstractItemModel):
                 return self.expandedIcon
             else:
                 return self.collapsedIcon
-        elif role == Qt.CheckStateRole:
+        elif role == Qt.ItemDataRole.CheckStateRole:
             item = index.internalPointer()
             if self.isTrack(item) and '#exact' in item.itemData:
                 if item.checked:
@@ -418,7 +418,7 @@ class TreeModel(QtCore.QAbstractItemModel):
 
     def headerData(self, section, orientation, role):
         if orientation == QtCore.Qt.Horizontal and \
-                role == QtCore.Qt.DisplayRole:
+                role == Qt.ItemDataRole.DisplayRole:
             ret = RETRIEVED_ALBUMS % ' / '.join(self.sortOrder)
 
             return ret
@@ -502,7 +502,7 @@ class TreeModel(QtCore.QAbstractItemModel):
 
         return parentItem.childCount()
 
-    def setData(self, index, value, role=Qt.CheckStateRole):
+    def setData(self, index, value, role=Qt.ItemDataRole.CheckStateRole):
         if index.isValid() and self.isTrack(index):
             item = index.internalPointer()
             item.checked = not item.checked

--- a/puddlestuff/releasewidget.py
+++ b/puddlestuff/releasewidget.py
@@ -272,8 +272,8 @@ class TreeModel(QtCore.QAbstractItemModel):
         self.trackPattern = track_pattern
         self.tagsource = tagsource
         icon = QWidget().style().standardIcon
-        self.expandedIcon = icon(QStyle.SP_DirOpenIcon)
-        self.collapsedIcon = icon(QStyle.SP_DirClosedIcon)
+        self.expandedIcon = icon(QStyle.StandardPixmap.SP_DirOpenIcon)
+        self.collapsedIcon = icon(QStyle.StandardPixmap.SP_DirClosedIcon)
 
         if data:
             self.setupModelData(data)

--- a/puddlestuff/shortcutsettings.py
+++ b/puddlestuff/shortcutsettings.py
@@ -3,7 +3,7 @@ import sys
 
 from PyQt5.QtCore import QEvent, QRect, Qt, pyqtRemoveInputHook
 from PyQt5.QtGui import QBrush, QKeySequence, QPainter, QPalette, QPen
-from PyQt5.QtWidgets import qApp, QApplication, QFrame, QItemDelegate, QLabel, \
+from PyQt5.QtWidgets import qApp, QAbstractItemDelegate, QApplication, QFrame, QItemDelegate, QLabel, \
     QTableWidget, QTableWidgetItem, QVBoxLayout, QWidget
 
 from . import loadshortcuts as ls
@@ -144,20 +144,20 @@ class ActionEditorDelegate(QItemDelegate):
                 obj.keyPressEvent(event)
                 if obj.valid:
                     self.commitData.emit(self.editor)
-                    self.closeEditor.emit(self.editor, QItemDelegate.NoHint)
+                    self.closeEditor.emit(self.editor, QAbstractItemDelegate.EndEditHint.NoHint)
                 return True
 
             elif event.type() == QEvent.KeyRelease:
                 obj.keyReleaseEvent(event)
                 if not obj.text():
-                    self.closeEditor.emit(self.editor, QItemDelegate.NoHint)
+                    self.closeEditor.emit(self.editor, QAbstractItemDelegate.EndEditHint.NoHint)
                 return True
 
             elif event.type() == QEvent.MouseButtonPress:
                 obj.mousePressEvent(event)
                 if obj.valid:
                     self.commitData.emit(self.editor)
-                    self.closeEditor.emit(self.editor, QItemDelegate.NoHint)
+                    self.closeEditor.emit(self.editor, QAbstractItemDelegate.EndEditHint.NoHint)
                 return True
 
         return False

--- a/puddlestuff/shortcutsettings.py
+++ b/puddlestuff/shortcutsettings.py
@@ -31,7 +31,7 @@ class ActionEditorWidget(QLabel):
         palette.setBrush(palette.Base, palette.brush(palette.AlternateBase))
         self.setPalette(palette)
         self.valid = False
-        self.setFrameStyle(QFrame.Panel)
+        self.setFrameStyle(QFrame.Shape.Panel)
 
     def keyPressEvent(self, event):
 

--- a/puddlestuff/shortcutsettings.py
+++ b/puddlestuff/shortcutsettings.py
@@ -203,7 +203,7 @@ class ActionEditorDialog(QWidget):
                                                      ' to <br />modify the key sequence.</b>'))
 
         self.actionTable = QTableWidget(self)
-        self.actionTable.setSelectionBehavior(QTableWidget.SelectRows)
+        self.actionTable.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
         self.actionTable.setEditTriggers(QAbstractItemView.EditTrigger.DoubleClicked)
         self.actionTable.setColumnCount(2)
         self.actionTable.setHorizontalHeaderLabels(

--- a/puddlestuff/shortcutsettings.py
+++ b/puddlestuff/shortcutsettings.py
@@ -140,20 +140,20 @@ class ActionEditorDelegate(QItemDelegate):
     def eventFilter(self, obj, event):
 
         if obj == self.editor:
-            if event.type() == QEvent.KeyPress:
+            if event.type() == QEvent.Type.KeyPress:
                 obj.keyPressEvent(event)
                 if obj.valid:
                     self.commitData.emit(self.editor)
                     self.closeEditor.emit(self.editor, QAbstractItemDelegate.EndEditHint.NoHint)
                 return True
 
-            elif event.type() == QEvent.KeyRelease:
+            elif event.type() == QEvent.Type.KeyRelease:
                 obj.keyReleaseEvent(event)
                 if not obj.text():
                     self.closeEditor.emit(self.editor, QAbstractItemDelegate.EndEditHint.NoHint)
                 return True
 
-            elif event.type() == QEvent.MouseButtonPress:
+            elif event.type() == QEvent.Type.MouseButtonPress:
                 obj.mousePressEvent(event)
                 if obj.valid:
                     self.commitData.emit(self.editor)

--- a/puddlestuff/shortcutsettings.py
+++ b/puddlestuff/shortcutsettings.py
@@ -37,14 +37,14 @@ class ActionEditorWidget(QLabel):
 
         other = None
 
-        if event.key() == Qt.Key_Shift:
-            self.modifiers[Qt.Key_Shift] = "Shift"
-        elif event.key() == Qt.Key_Control:
-            self.modifiers[Qt.Key_Control] = "Ctrl"
-        elif event.key() == Qt.Key_Meta:
-            self.modifiers[Qt.Key_Meta] = "Meta"
-        elif event.key() == Qt.Key_Alt:
-            self.modifiers[Qt.Key_Alt] = "Alt"
+        if event.key() == Qt.Key.Key_Shift:
+            self.modifiers[Qt.Key.Key_Shift] = "Shift"
+        elif event.key() == Qt.Key.Key_Control:
+            self.modifiers[Qt.Key.Key_Control] = "Ctrl"
+        elif event.key() == Qt.Key.Key_Meta:
+            self.modifiers[Qt.Key.Key_Meta] = "Meta"
+        elif event.key() == Qt.Key.Key_Alt:
+            self.modifiers[Qt.Key.Key_Alt] = "Alt"
         else:
             other = str(QKeySequence(event.key()))
 
@@ -61,18 +61,18 @@ class ActionEditorWidget(QLabel):
         if self.valid:
             return
 
-        if event.key() == Qt.Key_Shift:
-            if Qt.Key_Shift in self.modifiers:
-                del self.modifiers[Qt.Key_Shift]
-        elif event.key() == Qt.Key_Control:
-            if Qt.Key_Control in self.modifiers:
-                del self.modifiers[Qt.Key_Control]
-        elif event.key() == Qt.Key_Meta:
-            if Qt.Key_Meta in self.modifiers:
-                del self.modifiers[Qt.Key_Meta]
-        elif event.key() == Qt.Key_Alt:
-            if Qt.Key_Alt in self.modifiers:
-                del self.modifiers[Qt.Key_Alt]
+        if event.key() == Qt.Key.Key_Shift:
+            if Qt.Key.Key_Shift in self.modifiers:
+                del self.modifiers[Qt.Key.Key_Shift]
+        elif event.key() == Qt.Key.Key_Control:
+            if Qt.Key.Key_Control in self.modifiers:
+                del self.modifiers[Qt.Key.Key_Control]
+        elif event.key() == Qt.Key.Key_Meta:
+            if Qt.Key.Key_Meta in self.modifiers:
+                del self.modifiers[Qt.Key.Key_Meta]
+        elif event.key() == Qt.Key.Key_Alt:
+            if Qt.Key.Key_Alt in self.modifiers:
+                del self.modifiers[Qt.Key.Key_Alt]
 
         self.setText("+".join(list(self.modifiers.values())))
 

--- a/puddlestuff/shortcutsettings.py
+++ b/puddlestuff/shortcutsettings.py
@@ -81,7 +81,7 @@ class ActionEditorWidget(QLabel):
 
     def mousePressEvent(self, event):
 
-        if event.button() != Qt.LeftButton:
+        if event.button() != Qt.MouseButton.LeftButton:
             return
 
         size = self.height() / 2.0

--- a/puddlestuff/shortcutsettings.py
+++ b/puddlestuff/shortcutsettings.py
@@ -226,12 +226,12 @@ class ActionEditorDialog(QWidget):
 
             item = QTableWidgetItem()
             item.setText(action.text())
-            item.setFlags(Qt.ItemIsEnabled | Qt.ItemIsSelectable)
+            item.setFlags(Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable)
             self.actionTable.setItem(row, 0, item)
 
             item = QTableWidgetItem()
             item.setText(action.shortcut().toString())
-            item.setFlags(Qt.ItemIsEnabled | Qt.ItemIsEditable | Qt.ItemIsSelectable)
+            item.setFlags(Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsEditable | Qt.ItemFlag.ItemIsSelectable)
             item.oldShortcutText = item.text()
             self.actionTable.setItem(row, 1, item)
 

--- a/puddlestuff/shortcutsettings.py
+++ b/puddlestuff/shortcutsettings.py
@@ -3,7 +3,7 @@ import sys
 
 from PyQt5.QtCore import QEvent, QRect, Qt, pyqtRemoveInputHook
 from PyQt5.QtGui import QBrush, QKeySequence, QPainter, QPalette, QPen
-from PyQt5.QtWidgets import qApp, QAbstractItemDelegate, QApplication, QFrame, QItemDelegate, QLabel, \
+from PyQt5.QtWidgets import qApp, QAbstractItemDelegate, QAbstractItemView, QApplication, QFrame, QItemDelegate, QLabel, \
     QTableWidget, QTableWidgetItem, QVBoxLayout, QWidget
 
 from . import loadshortcuts as ls
@@ -204,7 +204,7 @@ class ActionEditorDialog(QWidget):
 
         self.actionTable = QTableWidget(self)
         self.actionTable.setSelectionBehavior(QTableWidget.SelectRows)
-        self.actionTable.setEditTriggers(QTableWidget.DoubleClicked)
+        self.actionTable.setEditTriggers(QAbstractItemView.EditTrigger.DoubleClicked)
         self.actionTable.setColumnCount(2)
         self.actionTable.setHorizontalHeaderLabels(
             [translate("Shortcut Settings", "Description"),

--- a/puddlestuff/shortcutsettings.py
+++ b/puddlestuff/shortcutsettings.py
@@ -171,7 +171,7 @@ class ActionEditorDelegate(QItemDelegate):
         painter.fillRect(option.rect, option.palette.brush(QPalette.Base))
         painter.setPen(QPen(option.palette.color(QPalette.Text)))
         painter.drawText(option.rect.adjusted(4, 4, -4, -4),
-                         Qt.TextShowMnemonic | Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter,
+                         Qt.TextFlag.TextShowMnemonic | Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter,
                          str(index.data()))
 
     def setEditorData(self, editor, index):

--- a/puddlestuff/shortcutsettings.py
+++ b/puddlestuff/shortcutsettings.py
@@ -97,7 +97,7 @@ class ActionEditorWidget(QLabel):
         if self.text():
             painter = QPainter()
             painter.begin(self)
-            painter.setRenderHint(QPainter.Antialiasing)
+            painter.setRenderHint(QPainter.RenderHint.Antialiasing)
 
             color = self.palette().color(QPalette.Highlight)
             color.setAlpha(127)

--- a/puddlestuff/shortcutsettings.py
+++ b/puddlestuff/shortcutsettings.py
@@ -28,7 +28,7 @@ class ActionEditorWidget(QLabel):
         self.modifiers = {}
         self.setAutoFillBackground(True)
         palette = self.palette()
-        palette.setBrush(palette.Base, palette.brush(palette.AlternateBase))
+        palette.setBrush(QPalette.ColorRole.Base, palette.brush(QPalette.ColorRole.AlternateBase))
         self.setPalette(palette)
         self.valid = False
         self.setFrameStyle(QFrame.Shape.Panel)
@@ -99,10 +99,10 @@ class ActionEditorWidget(QLabel):
             painter.begin(self)
             painter.setRenderHint(QPainter.RenderHint.Antialiasing)
 
-            color = self.palette().color(QPalette.Highlight)
+            color = self.palette().color(QPalette.ColorRole.Highlight)
             color.setAlpha(127)
             painter.setBrush(QBrush(color))
-            color = self.palette().color(QPalette.HighlightedText)
+            color = self.palette().color(QPalette.ColorRole.HighlightedText)
             color.setAlpha(127)
             painter.setPen(QPen(color))
             size = self.height() / 2.0
@@ -168,8 +168,8 @@ class ActionEditorDelegate(QItemDelegate):
             QItemDelegate.paint(self, painter, option, index)
             return
 
-        painter.fillRect(option.rect, option.palette.brush(QPalette.Base))
-        painter.setPen(QPen(option.palette.color(QPalette.Text)))
+        painter.fillRect(option.rect, option.palette.brush(QPalette.ColorRole.Base))
+        painter.setPen(QPen(option.palette.color(QPalette.ColorRole.Text)))
         painter.drawText(option.rect.adjusted(4, 4, -4, -4),
                          Qt.TextFlag.TextShowMnemonic | Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter,
                          str(index.data()))

--- a/puddlestuff/shortcutsettings.py
+++ b/puddlestuff/shortcutsettings.py
@@ -171,7 +171,7 @@ class ActionEditorDelegate(QItemDelegate):
         painter.fillRect(option.rect, option.palette.brush(QPalette.Base))
         painter.setPen(QPen(option.palette.color(QPalette.Text)))
         painter.drawText(option.rect.adjusted(4, 4, -4, -4),
-                         Qt.TextShowMnemonic | Qt.AlignLeft | Qt.AlignVCenter,
+                         Qt.TextShowMnemonic | Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter,
                          str(index.data()))
 
     def setEditorData(self, editor, index):

--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -10,7 +10,7 @@ from subprocess import Popen
 from PyQt5.QtCore import QAbstractTableModel, QEvent, QItemSelection, QItemSelectionModel, QItemSelectionRange, \
     QMimeData, QModelIndex, QPoint, QUrl, Qt, pyqtSignal
 from PyQt5.QtGui import QColor, QFont, QDrag, QPalette
-from PyQt5.QtWidgets import QAbstractItemDelegate, QAction, QApplication, QDialog, QGridLayout, QGroupBox, \
+from PyQt5.QtWidgets import QAbstractItemDelegate, QAbstractItemView, QAction, QApplication, QDialog, QGridLayout, QGroupBox, \
     QHBoxLayout, QHeaderView, QLabel, QLineEdit, QMenu, QMessageBox, QPushButton, QStyledItemDelegate, QTableView, \
     QVBoxLayout
 
@@ -1829,7 +1829,7 @@ class TagTable(QTableView):
         # control key.
         elif event.key() == Qt.Key.Key_Space and (has_modifier):
             trigger = self.editTriggers()
-            self.setEditTriggers(self.NoEditTriggers)
+            self.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
             ret = QTableView.keyPressEvent(self, event)
             self.setEditTriggers(trigger)
             return ret

--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -419,8 +419,8 @@ class ColumnSettings(HeaderSetting):
 
         if not checked:
             checked = list(range(len(tags)))
-        [z.setCheckState(Qt.Checked) if i in checked
-         else z.setCheckState(Qt.Unchecked) for i, z in enumerate(items)]
+        [z.setCheckState(Qt.CheckState.Checked) if i in checked
+         else z.setCheckState(Qt.CheckState.Unchecked) for i, z in enumerate(items)]
 
     def applySettings(self, control=None):
         row = self.listbox.currentRow()

--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -35,7 +35,7 @@ the_break = False
 status = {}
 
 LIBRARY = '__library'
-HIGHLIGHTCOLOR = Qt.green
+HIGHLIGHTCOLOR = Qt.GlobalColor.green
 SHIFT_RETURN = 2
 RETURN_ONLY = 1
 
@@ -499,7 +499,7 @@ class TagModel(QAbstractTableModel):
         self._previewMode = False
         self._prevhighlight = []
         self._permah = []
-        self.permaColor = QColor(Qt.green)
+        self.permaColor = QColor(Qt.GlobalColor.green)
         self._colored = []
         audioinfo.Tag = _Tag(self)
         audioinfo.model_tag = partial(model_tag, self)

--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -2411,7 +2411,7 @@ class TagTable(QTableView):
         self.selectionModel().select(selection,
                                      QItemSelectionModel.ClearAndSelect)
 
-        self.scrollTo(get_index(row, min(columns)), self.EnsureVisible)
+        self.scrollTo(get_index(row, min(columns)), QAbstractItemView.ScrollHint.EnsureVisible)
 
     def selectDir(self, previous=False):
         model = self.model()

--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -134,7 +134,7 @@ def has_previews(tags=None, parent=None, msg=None):
 
     if previews and confirmations.should_show('preview_mode'):
         ret = QMessageBox.question(parent, 'puddletag', msg)
-        if ret != QMessageBox.Yes:
+        if ret != QMessageBox.StandardButton.Yes:
             return True
     return False
 
@@ -1648,8 +1648,8 @@ class TagTable(QTableView):
             result = QMessageBox.question(self, "puddletag",
                                           translate("Table", "Are you sure you want to delete the selected files?"))
         else:
-            result = QMessageBox.Yes
-        if result != QMessageBox.Yes:
+            result = QMessageBox.StandardButton.Yes
+        if result != QMessageBox.StandardButton.Yes:
             return
         selected = self.selectedTags
         selectedRows = self.selectedRows
@@ -2102,7 +2102,7 @@ class TagTable(QTableView):
         if previews:
             ret = QMessageBox.question(self, 'puddletag',
                 translate("Previews", 'There are unsaved changes pending. Do you want to discard and reload?'))
-            if ret != QMessageBox.Yes:
+            if ret != QMessageBox.StandardButton.Yes:
                 return
 
         self._restore = self.saveSelection()

--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -493,7 +493,7 @@ class TagModel(QAbstractTableModel):
         self._headerData = []
         self.headerdata = headerdata
         self.colorRows = []
-        self.sortOrder = (0, Qt.AscendingOrder)
+        self.sortOrder = (0, Qt.SortOrder.AscendingOrder)
         self.saveModification = True
         self._filtered = []
         self._previewMode = False
@@ -1151,7 +1151,7 @@ class TagModel(QAbstractTableModel):
             return self.index(row, column)
         return QModelIndex();
 
-    def sort(self, column, order=Qt.DescendingOrder):
+    def sort(self, column, order=Qt.SortOrder.DescendingOrder):
         try:
             field = self.headerdata[column][1]
         except IndexError:
@@ -1159,7 +1159,7 @@ class TagModel(QAbstractTableModel):
                 field = self.headerdata[0][1]
             else:
                 return
-        if order == Qt.DescendingOrder:
+        if order == Qt.SortOrder.DescendingOrder:
             self.sortByFields([field], reverse=True)
         else:
             self.sortByFields([field], reverse=False)
@@ -1307,7 +1307,7 @@ class TableHeader(QHeaderView):
         self.setHighlightSections(True)
         self.setSectionsMovable(True)
         self.setSortIndicatorShown(True)
-        self.setSortIndicator(0, Qt.AscendingOrder)
+        self.setSortIndicator(0, Qt.SortOrder.AscendingOrder)
 
     def contextMenuEvent(self, event):
         menu = QMenu(self)

--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -1026,7 +1026,7 @@ class TagModel(QAbstractTableModel):
     def setData(self, index, value, role=Qt.EditRole, dontwrite=False):
         """Sets the data of the currently edited cell as expected.
         Also writes tags and increases the undolevel."""
-        QApplication.setOverrideCursor(Qt.WaitCursor);
+        QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor);
         if index.isValid() and 0 <= index.row() < len(self.taginfo):
             column = index.column()
             tag = self.headerdata[column][1]
@@ -2237,11 +2237,11 @@ class TagTable(QTableView):
             self.tagselectionchanged.emit()
 
     def saveBeforeReset(self):
-        self.setCursor(Qt.BusyCursor)
+        self.setCursor(Qt.CursorShape.BusyCursor)
         self._savedSelection = self.saveSelection()
 
     def restoreSort(self):
-        self.setCursor(Qt.ArrowCursor)
+        self.setCursor(Qt.CursorShape.ArrowCursor)
         if self._savedSelection:
             self.restoreSelection(self._savedSelection)
             self._savedSelection = None

--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -1276,9 +1276,9 @@ class TagDelegate(QStyledItemDelegate):
         if event.type() == QEvent.KeyPress:
             if event.key() in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
                 if event.key() == Qt.Key.Key_Return:
-                    shift_pressed = event.modifiers() == Qt.ShiftModifier
+                    shift_pressed = event.modifiers() == Qt.KeyboardModifier.ShiftModifier
                 else:
-                    shift_pressed = event.modifiers() == Qt.ShiftModifier | Qt.KeypadModifier
+                    shift_pressed = event.modifiers() == Qt.KeyboardModifier.ShiftModifier | Qt.KeyboardModifier.KeypadModifier
                 if shift_pressed:
                     editor.returnPressed = SHIFT_RETURN
                 else:
@@ -1760,7 +1760,7 @@ class TagTable(QTableView):
         urls = list(map(QUrl.fromLocalFile, list(map(decode_fn, filenames))))
         mimeData = QMimeData()
         mimeData.setUrls(urls)
-        if event.modifiers() == Qt.MetaModifier:
+        if event.modifiers() == Qt.KeyboardModifier.MetaModifier:
             mimeData.draggedRows = self.selectedRows[::]
         else:
             mimeData.draggedRows = None
@@ -1821,7 +1821,7 @@ class TagTable(QTableView):
         # action is defined in contextMenuEvent, but if this isn't
         # done then the delegate is entered.
 
-        has_modifier = event.modifiers() in [Qt.ControlModifier, Qt.ShiftModifier, Qt.ControlModifier | Qt.ShiftModifier]
+        has_modifier = event.modifiers() in [Qt.KeyboardModifier.ControlModifier, Qt.KeyboardModifier.ShiftModifier, Qt.KeyboardModifier.ControlModifier | Qt.KeyboardModifier.ShiftModifier]
         if event.key() == Qt.Key.Key_Delete and self.selectedRows:
             self.deleteSelected()
             return

--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -1400,7 +1400,7 @@ class TagTable(QTableView):
         self._playlist = False
         self.filespec = ''
         self.contextMenu = None
-        self.setHorizontalScrollMode(self.ScrollPerPixel)
+        self.setHorizontalScrollMode(QAbstractItemView.ScrollMode.ScrollPerPixel)
 
         model = TagModel(headerdata)
         header.headerChanged.connect(self.setHeaderTags)

--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -1552,17 +1552,17 @@ class TagTable(QTableView):
         self.model().reset()
         self.dirschanged.emit([])
 
-    def _closeEditor(self, editor, hint=QAbstractItemDelegate.NoHint):
+    def _closeEditor(self, editor, hint=QAbstractItemDelegate.EndEditHint.NoHint):
         if editor.writeError:
             model = self.model()
             currentfile = model.taginfo[self.currentIndex().row()]
-            QTableView.closeEditor(self, editor, QAbstractItemDelegate.NoHint)
+            QTableView.closeEditor(self, editor, QAbstractItemDelegate.EndEditHint.NoHint)
             model.setDataError.emit(
                 rename_error_msg(editor.writeError, currentfile.filepath))
             return
 
         if len(self.selectedRows) > 1:
-            QTableView.closeEditor(self, editor, QAbstractItemDelegate.NoHint)
+            QTableView.closeEditor(self, editor, QAbstractItemDelegate.EndEditHint.NoHint)
         elif not editor.returnPressed:
             QTableView.closeEditor(self, editor, hint)
         else:
@@ -1579,11 +1579,11 @@ class TagTable(QTableView):
                                                   index.column())
 
             if newindex:
-                QTableView.closeEditor(self, editor, QAbstractItemDelegate.NoHint)
+                QTableView.closeEditor(self, editor, QAbstractItemDelegate.EndEditHint.NoHint)
                 self.setCurrentIndex(newindex)
                 self.edit(newindex)
             else:
-                QTableView.closeEditor(self, editor, QAbstractItemDelegate.NoHint)
+                QTableView.closeEditor(self, editor, QAbstractItemDelegate.EndEditHint.NoHint)
 
     def removeTags(self):
         if self.model().previewMode:

--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -762,9 +762,9 @@ class TagModel(QAbstractTableModel):
 
     def flags(self, index):
         if not index.isValid():
-            return Qt.ItemIsEnabled
-        return Qt.ItemFlags(QAbstractTableModel.flags(self, index) |
-                            Qt.ItemIsEditable | Qt.ItemIsDropEnabled)
+            return Qt.ItemFlag.ItemIsEnabled
+        return Qt.ItemFlag(QAbstractTableModel.flags(self, index) |
+                            Qt.ItemFlag.ItemIsEditable | Qt.ItemFlag.ItemIsDropEnabled)
 
     def headerData(self, section, orientation, role=Qt.ItemDataRole.DisplayRole):
         if role == Qt.ItemDataRole.TextAlignmentRole:

--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -1273,7 +1273,7 @@ class TagDelegate(QStyledItemDelegate):
         return editor
 
     def eventFilter(self, editor, event):
-        if event.type() == QEvent.KeyPress:
+        if event.type() == QEvent.Type.KeyPress:
             if event.key() in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
                 if event.key() == Qt.Key.Key_Return:
                     shift_pressed = event.modifiers() == Qt.KeyboardModifier.ShiftModifier

--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -1954,7 +1954,7 @@ class TagTable(QTableView):
 
         cparser = PuddleConfig()
         preview_color = cparser.get('table', 'preview_color', [192, 255, 192], True)
-        default = QPalette().color(QPalette.Mid).getRgb()[:-1]
+        default = QPalette().color(QPalette.ColorRole.Mid).getRgb()[:-1]
         selection_color = cparser.get('table', 'selected_color', default, True)
 
         model = self.model()

--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -1318,7 +1318,7 @@ class TableHeader(QHeaderView):
         menu.exec_(event.globalPos())
 
     def mousePressEvent(self, event):
-        if event.button == Qt.RightButton:
+        if event.button == Qt.MouseButton.RightButton:
             self.contextMenuEvent(event)
             return
         QHeaderView.mousePressEvent(self, event)
@@ -1741,7 +1741,7 @@ class TagTable(QTableView):
 
     def mouseMoveEvent(self, event):
 
-        if event.buttons() != Qt.LeftButton:
+        if event.buttons() != Qt.MouseButton.LeftButton:
             return
         mimeData = QMimeData()
         plainText = ""
@@ -1774,7 +1774,7 @@ class TagTable(QTableView):
                 self.deleteSelected(False, False, False)
 
     def mousePressEvent(self, event):
-        if event.buttons() == Qt.LeftButton:
+        if event.buttons() == Qt.MouseButton.LeftButton:
             self.StartPosition = [event.pos().x(), event.pos().y()]
         QTableView.mousePressEvent(self, event)
 

--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -687,12 +687,12 @@ class TagModel(QAbstractTableModel):
             except TypeError:
                 return str(val)
 
-    def data(self, index, role=Qt.DisplayRole):
+    def data(self, index, role=Qt.ItemDataRole.DisplayRole):
         row = index.row()
         if not index.isValid() or not (0 <= row < len(self.taginfo)):
             return None
 
-        if role in (Qt.DisplayRole, Qt.ToolTipRole, Qt.EditRole):
+        if role in (Qt.ItemDataRole.DisplayRole, Qt.ItemDataRole.ToolTipRole, Qt.ItemDataRole.EditRole):
             try:
                 audio = self.taginfo[row]
                 tag = self.headerdata[index.column()][1]
@@ -700,7 +700,7 @@ class TagModel(QAbstractTableModel):
             except (KeyError, IndexError):
                 return None
 
-            if role == Qt.ToolTipRole:
+            if role == Qt.ItemDataRole.ToolTipRole:
                 if not self.showToolTip:
                     return None
                 if self.previewMode and \
@@ -719,13 +719,13 @@ class TagModel(QAbstractTableModel):
                     tooltip = val
                 return tooltip
             return val
-        elif role == Qt.BackgroundColorRole:
+        elif role == Qt.ItemDataRole.BackgroundColorRole:
             audio = self.taginfo[row]
             if audio.color:
                 return audio.color
             elif self.previewMode and audio.preview:
                 return self.previewBackground
-        elif role == Qt.FontRole:
+        elif role == Qt.ItemDataRole.FontRole:
 
             field = self.headerdata[index.column()][1]
             f = QFont()
@@ -766,12 +766,12 @@ class TagModel(QAbstractTableModel):
         return Qt.ItemFlags(QAbstractTableModel.flags(self, index) |
                             Qt.ItemIsEditable | Qt.ItemIsDropEnabled)
 
-    def headerData(self, section, orientation, role=Qt.DisplayRole):
-        if role == Qt.TextAlignmentRole:
+    def headerData(self, section, orientation, role=Qt.ItemDataRole.DisplayRole):
+        if role == Qt.ItemDataRole.TextAlignmentRole:
             if orientation == Qt.Horizontal:
                 return int(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
             return int(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
-        if role != Qt.DisplayRole:
+        if role != Qt.ItemDataRole.DisplayRole:
             return None
         if orientation == Qt.Horizontal:
             try:
@@ -1023,7 +1023,7 @@ class TagModel(QAbstractTableModel):
     def rowCount(self, index=QModelIndex()):
         return len(self.taginfo)
 
-    def setData(self, index, value, role=Qt.EditRole, dontwrite=False):
+    def setData(self, index, value, role=Qt.ItemDataRole.EditRole, dontwrite=False):
         """Sets the data of the currently edited cell as expected.
         Also writes tags and increases the undolevel."""
         QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor);
@@ -1054,8 +1054,8 @@ class TagModel(QAbstractTableModel):
             return True
         return False
 
-    def setHeaderData(self, section, orientation, value, role=Qt.EditRole):
-        if (orientation == Qt.Horizontal) and (role == Qt.DisplayRole):
+    def setHeaderData(self, section, orientation, value, role=Qt.ItemDataRole.EditRole):
+        if (orientation == Qt.Horizontal) and (role == Qt.ItemDataRole.DisplayRole):
             self.headerdata[section] = value
 
         self.headerdata = self.headerdata  # make sure columns are set
@@ -2151,7 +2151,7 @@ class TagTable(QTableView):
         model.dirsmoved.connect(self.dirsmoved)
         set_data = model.setData
 
-        def modded_setData(index, value, role=Qt.EditRole):
+        def modded_setData(index, value, role=Qt.ItemDataRole.EditRole):
             if len(self.selectedRows) == 1:
                 return set_data(index, value, role)
             ret = set_data(index, value, role, True)

--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -412,7 +412,7 @@ class ColumnSettings(HeaderSetting):
         if showok:
             winsettings('columnsettings', self)
 
-        self.setWindowFlags(Qt.Widget)
+        self.setWindowFlags(Qt.WindowType.Widget)
         label = QLabel(translate("Column Settings", 'Adjust visibility of columns.'))
         self.grid.addWidget(label, 0, 0)
         items = [self.listbox.item(z) for z in range(self.listbox.count())]

--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -1813,7 +1813,7 @@ class TagTable(QTableView):
         bottomRight = model.index(model.rowCount() - 1, model.columnCount() - 1)
 
         selection = QItemSelection(topLeft, bottomRight)
-        self.selectionModel().select(selection, QItemSelectionModel.Toggle)
+        self.selectionModel().select(selection, QItemSelectionModel.SelectionFlag.Toggle)
 
     def keyPressEvent(self, event):
         event.accept()
@@ -2131,12 +2131,12 @@ class TagTable(QTableView):
             bottomRight = model.index(model.rowCount() - 1, col)
 
             selection = QItemSelection(topLeft, bottomRight)
-            self.selectionModel().select(selection, QItemSelectionModel.Select)
+            self.selectionModel().select(selection, QItemSelectionModel.SelectionFlag.Select)
 
     def selectCorner(self):
         topLeft = self.model().index(0, 0)
         selection = QItemSelection(topLeft, topLeft)
-        self.selectionModel().select(selection, QItemSelectionModel.Select)
+        self.selectionModel().select(selection, QItemSelectionModel.SelectionFlag.Select)
         self.setCurrentIndex(topLeft)
 
     def setModel(self, model):
@@ -2302,7 +2302,7 @@ class TagTable(QTableView):
 
         for col, rows in groups.items():
             [select(min(row), max(row), col) for row in rows]
-        self.selectionModel().select(selection, QItemSelectionModel.Select)
+        self.selectionModel().select(selection, QItemSelectionModel.SelectionFlag.Select)
 
     def restoreSelection(self, data=None):
         if data is None:
@@ -2329,7 +2329,7 @@ class TagTable(QTableView):
                     select_index(row, column)
 
         self.selectionModel().clear()
-        self.selectionModel().select(selection, QItemSelectionModel.SelectCurrent)
+        self.selectionModel().select(selection, QItemSelectionModel.SelectionFlag.SelectCurrent)
         self.model().highlight(self.selectedRows)
 
     def removeFolders(self, dirs, valid=True):
@@ -2407,9 +2407,9 @@ class TagTable(QTableView):
         for column in columns:
             index = get_index(row, column)
             selection.merge(QItemSelection(index, index),
-                            QItemSelectionModel.Select)
+                            QItemSelectionModel.SelectionFlag.Select)
         self.selectionModel().select(selection,
-                                     QItemSelectionModel.ClearAndSelect)
+                                     QItemSelectionModel.SelectionFlag.ClearAndSelect)
 
         self.scrollTo(get_index(row, min(columns)), QAbstractItemView.ScrollHint.EnsureVisible)
 
@@ -2453,9 +2453,9 @@ class TagTable(QTableView):
 
         for row, column in to_select.items():
             index = modelindex(row, column)
-            merge(QItemSelection(index, index), QItemSelectionModel.Select)
+            merge(QItemSelection(index, index), QItemSelectionModel.SelectionFlag.Select)
 
-        self.selectionModel().select(selection, QItemSelectionModel.Select)
+        self.selectionModel().select(selection, QItemSelectionModel.SelectionFlag.Select)
 
     def showProperties(self):
         f = self.selectedTags[0]

--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -769,8 +769,8 @@ class TagModel(QAbstractTableModel):
     def headerData(self, section, orientation, role=Qt.DisplayRole):
         if role == Qt.TextAlignmentRole:
             if orientation == Qt.Horizontal:
-                return int(Qt.AlignLeft | Qt.AlignVCenter)
-            return int(Qt.AlignRight | Qt.AlignVCenter)
+                return int(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
+            return int(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
         if role != Qt.DisplayRole:
             return None
         if orientation == Qt.Horizontal:

--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -1188,7 +1188,7 @@ class TagModel(QAbstractTableModel):
         self.sorted.emit()
 
     def supportedDropActions(self):
-        return Qt.CopyAction
+        return Qt.DropAction.CopyAction
 
     def undo(self):
         """Undos the last action.
@@ -1769,7 +1769,7 @@ class TagTable(QTableView):
         drag.setMimeData(mimeData)
         drag.setHotSpot(event.pos() - self.rect().topLeft())
         dropaction = drag.exec_()
-        if dropaction == Qt.MoveAction:
+        if dropaction == Qt.DropAction.MoveAction:
             if not os.path.exists(filenames[0]):
                 self.deleteSelected(False, False, False)
 

--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -1274,8 +1274,8 @@ class TagDelegate(QStyledItemDelegate):
 
     def eventFilter(self, editor, event):
         if event.type() == QEvent.KeyPress:
-            if event.key() in (Qt.Key_Return, Qt.Key_Enter):
-                if event.key() == Qt.Key_Return:
+            if event.key() in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
+                if event.key() == Qt.Key.Key_Return:
                     shift_pressed = event.modifiers() == Qt.ShiftModifier
                 else:
                     shift_pressed = event.modifiers() == Qt.ShiftModifier | Qt.KeypadModifier
@@ -1822,12 +1822,12 @@ class TagTable(QTableView):
         # done then the delegate is entered.
 
         has_modifier = event.modifiers() in [Qt.ControlModifier, Qt.ShiftModifier, Qt.ControlModifier | Qt.ShiftModifier]
-        if event.key() == Qt.Key_Delete and self.selectedRows:
+        if event.key() == Qt.Key.Key_Delete and self.selectedRows:
             self.deleteSelected()
             return
         # This is so that an item isn't edited when the user's holding the shift or
         # control key.
-        elif event.key() == Qt.Key_Space and (has_modifier):
+        elif event.key() == Qt.Key.Key_Space and (has_modifier):
             trigger = self.editTriggers()
             self.setEditTriggers(self.NoEditTriggers)
             ret = QTableView.keyPressEvent(self, event)

--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -768,12 +768,12 @@ class TagModel(QAbstractTableModel):
 
     def headerData(self, section, orientation, role=Qt.ItemDataRole.DisplayRole):
         if role == Qt.ItemDataRole.TextAlignmentRole:
-            if orientation == Qt.Horizontal:
+            if orientation == Qt.Orientation.Horizontal:
                 return int(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
             return int(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
         if role != Qt.ItemDataRole.DisplayRole:
             return None
-        if orientation == Qt.Horizontal:
+        if orientation == Qt.Orientation.Horizontal:
             try:
                 return str(self.headerdata[section][0])
             except IndexError:
@@ -1055,7 +1055,7 @@ class TagModel(QAbstractTableModel):
         return False
 
     def setHeaderData(self, section, orientation, value, role=Qt.ItemDataRole.EditRole):
-        if (orientation == Qt.Horizontal) and (role == Qt.ItemDataRole.DisplayRole):
+        if (orientation == Qt.Orientation.Horizontal) and (role == Qt.ItemDataRole.DisplayRole):
             self.headerdata[section] = value
 
         self.headerdata = self.headerdata  # make sure columns are set
@@ -1065,7 +1065,7 @@ class TagModel(QAbstractTableModel):
     def setHeader(self, tags):
         self.headerdata = tags
         self.headerDataChanged.emit(
-            Qt.Horizontal, 0, len(self.headerdata))
+            Qt.Orientation.Horizontal, 0, len(self.headerdata))
         self.reset()
 
     def setRowData(self, row, tags, undo=False, justrename=False, temp=False):
@@ -1375,12 +1375,12 @@ class TagTable(QTableView):
         self.settingsdialog = ColumnSettings
         if not headerdata:
             headerdata = []
-        header = TableHeader(Qt.Horizontal, headerdata, self)
+        header = TableHeader(Qt.Orientation.Horizontal, headerdata, self)
         header.setSortIndicatorShown(True)
         self.setSortingEnabled(True)
         self._savedSelection = False
 
-        self.setVerticalHeader(VerticalHeader(Qt.Vertical))
+        self.setVerticalHeader(VerticalHeader(Qt.Orientation.Vertical))
         self.setHorizontalHeader(header)
         self.setDragEnabled(True)
         self.setAcceptDrops(True)
@@ -2340,7 +2340,7 @@ class TagTable(QTableView):
     def setHeaderTags(self, tags, hidden=None):
 
         self.saveSelection()
-        hd = TableHeader(Qt.Horizontal, tags, self)
+        hd = TableHeader(Qt.Orientation.Horizontal, tags, self)
         hd.setSortIndicatorShown(True)
         hd.setVisible(True)
         hd.headerChanged.connect(self.setHeaderTags)

--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -358,7 +358,7 @@ class Properties(QDialog):
 
     def _load(self, info):
         vbox = QVBoxLayout()
-        interaction = Qt.TextSelectableByMouse or Qt.TextSelectableByKeyboard
+        interaction = Qt.TextInteractionFlag.TextSelectableByMouse | Qt.TextInteractionFlag.TextSelectableByKeyboard
         for title, items in info:
             frame = QGroupBox(title)
             framegrid = QGridLayout()

--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -1371,7 +1371,7 @@ class TagTable(QTableView):
 
     def __init__(self, headerdata=None, parent=None):
         QTableView.__init__(self, parent)
-        self.setSelectionMode(self.ExtendedSelection)
+        self.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
         self.settingsdialog = ColumnSettings
         if not headerdata:
             headerdata = []

--- a/puddlestuff/webdb.py
+++ b/puddlestuff/webdb.py
@@ -236,9 +236,9 @@ class SimpleDialog(QDialog):
             elif ctype == CHECKBOX:
                 control = QCheckBox(desc)
                 if default:
-                    control.setCheckState(Qt.Checked)
+                    control.setCheckState(Qt.CheckState.Checked)
                 else:
-                    control.setCheckState(Qt.Unchecked)
+                    control.setCheckState(Qt.CheckState.Unchecked)
                 vbox.addWidget(control)
             elif ctype == SPINBOX:
                 control = QSpinBox()

--- a/puddlestuff/webdb.py
+++ b/puddlestuff/webdb.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 
 from PyQt5.QtCore import Qt, pyqtRemoveInputHook, pyqtSignal
 from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import QApplication, QCheckBox, QComboBox, QDialog, QGroupBox, QHBoxLayout, \
+from PyQt5.QtWidgets import QAbstractItemView, QApplication, QCheckBox, QComboBox, QDialog, QGroupBox, QHBoxLayout, \
     QInputDialog, QLabel, QLineEdit, QPushButton, QSpinBox, QTextEdit, QToolButton, QVBoxLayout, \
     QWidget
 
@@ -282,7 +282,7 @@ class SortOptionEditor(QDialog):
         QDialog.__init__(self, parent)
         connect = lambda c, signal, s: getattr(c, signal).connect(s)
         self.listbox = ListBox()
-        self.listbox.setSelectionMode(self.listbox.ExtendedSelection)
+        self.listbox.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
 
         buttons = ListButtons()
 

--- a/puddletag
+++ b/puddletag
@@ -226,14 +226,14 @@ def load_language(qapp, langfile=None):
     if langargs and langargs != 'default':
         translator = QTranslator()
         translator.load("qt_" + QLocale.system().name(),
-                        QLibraryInfo.location(QLibraryInfo.TranslationsPath))
+                        QLibraryInfo.location(QLibraryInfo.LibraryLocation.TranslationsPath))
         translators.append(translator)
 
         if 'puddletag_' in langargs[0]:
             translator = QTranslator()
             locale = langargs[0][len('puddletag_'):-len('.qm')]
             translator.load("qt_" + locale,
-                            QLibraryInfo.location(QLibraryInfo.TranslationsPath))
+                            QLibraryInfo.location(QLibraryInfo.LibraryLocation.TranslationsPath))
             print("Locale: " + locale)
             translators.append(translator)
 
@@ -244,7 +244,7 @@ def load_language(qapp, langfile=None):
     elif langargs != 'default':
         translator = QTranslator()
         translator.load("qt_" + QLocale.system().name(),
-                        QLibraryInfo.location(QLibraryInfo.TranslationsPath))
+                        QLibraryInfo.location(QLibraryInfo.LibraryLocation.TranslationsPath))
         print("Locale: " + str(QLocale.system().name()))
         translators.append(translator)
 


### PR DESCRIPTION
Traditionally, enum members in Qt were not scoped to the enum itself but the parent of the enum. Take the enum [`Qt::AlignmentFlag`](https://doc.qt.io/qt-5/qt.html#AlignmentFlag-enum) as an example: Its member `AlignLeft` is in the same scope (the `Qt` namespace), and can be referenced by `Qt::AlignLeft` instead of `Qt::AlignmentFlag::AlignLeft`. This stems from the way enums are implemented in C/C++.
This changed recently starting in Qt itself, and now manifesting in PyQt in a major way. In PyQt4 and earlier versions of PyQt5, enum members were only accessible like in Qt with `Qt.AlignLeft`. Starting with PyQt v5.11, they are accessible with both `Qt.AlignLeft` and `Qt.AlignmentFlag.AlignLeft`. And [starting with PyQt6](https://www.riverbankcomputing.com/static/Docs/PyQt5/gotchas.html#enums) only `Qt.AlignmentFlag.AlignLeft` is allowed, which means all uses of enums have to have the scope added, which is exactly what this PR does. This should have no functional impacts, everything will (or at least should) work exactly the same as before.

Feel free to squash some or all of the commits before merging, I left them separate to make the review easier.

