### PR TITLE
Replace obsolete PyQt5 things

### DIFF
--- a/puddlestuff/actiondlg.py
+++ b/puddlestuff/actiondlg.py
@@ -477,7 +477,7 @@ class CreateFunction(QDialog):
         else:
             self.createWindow(0)
 
-        self.functions.activated.connect(self.createWindow)
+        self.functions.textActivated.connect(self.createWindow)
 
         self.vbox.addWidget(self.exlabel)
         self.vbox.addLayout(self.okcancel)

--- a/puddlestuff/helperwin.py
+++ b/puddlestuff/helperwin.py
@@ -570,7 +570,7 @@ class StatusWidgetCombo(QComboBox):
 
     def background(self):
         brush = QBrush()
-        brush.setColor(self.palette().color(QPalette.ColorRole.Background))
+        brush.setColor(self.palette().color(QPalette.ColorRole.Window))
         return brush
 
     def reset(self):

--- a/puddlestuff/helperwin.py
+++ b/puddlestuff/helperwin.py
@@ -515,7 +515,7 @@ class StatusWidgetCombo(QComboBox):
         self.preview = preview
 
         self.statusColors = colors
-        self.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToMinimumContentsLength)
+        self.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToContents)
 
         items = map(str, items)
         items = sorted(items, key=natsort_case_key)

--- a/puddlestuff/libraries/quodlibetlib.py
+++ b/puddlestuff/libraries/quodlibetlib.py
@@ -7,7 +7,7 @@ from functools import partial
 
 import quodlibet.config
 from PyQt5.QtCore import QDir, Qt
-from PyQt5.QtWidgets import QCompleter, QDirModel, QFileDialog, QHBoxLayout, QLabel, QLineEdit, QPushButton, QVBoxLayout, QWidget
+from PyQt5.QtWidgets import QCompleter, QFileDialog, QFileSystemModel, QHBoxLayout, QLabel, QLineEdit, QPushButton, QVBoxLayout, QWidget
 from quodlibet.parse import Query
 
 from .. import audioinfo
@@ -323,27 +323,17 @@ class QuodLibet(object):
         cached[trackartist][trackalbum].append(track)
 
 
-class DirModel(QDirModel):
-
-    def data(self, index, role=Qt.ItemDataRole.DisplayRole):
-        if (role == Qt.ItemDataRole.DisplayRole and index.column() == 0):
-            path = QDir.toNativeSeparators(self.filePath(index))
-            if path.endsWith(QDir.separator()):
-                path.chop(1)
-            return path
-        return QDirModel.data(self, index, role)
-
-
 class DirLineEdit(QLineEdit):
     def __init__(self, *args, **kwargs):
         super(DirLineEdit, self).__init__(*args, **kwargs)
         completer = QCompleter()
         completer.setCompletionMode(QCompleter.CompletionMode.PopupCompletion)
-        dirfilter = QDir.Filter.AllEntries | QDir.Filter.NoDotAndDotDot | QDir.Filter.Hidden
-        sortflags = QDir.SortFlag.DirsFirst | QDir.SortFlag.IgnoreCase
 
-        dirmodel = QDirModel(['*'], dirfilter, sortflags, completer)
-        completer.setModel(dirmodel)
+        model = QFileSystemModel()
+        model.setRootPath('/')
+        model.setFilter(QDir.Filter.AllEntries | QDir.Filter.NoDotAndDotDot | QDir.Filter.Hidden)
+        completer.setModel(model)
+
         self.setCompleter(completer)
 
 

--- a/puddlestuff/m3u.py
+++ b/puddlestuff/m3u.py
@@ -130,7 +130,8 @@ def exportm3u(tags, tofile, format=None, reldir=False, winsep=False):
 if __name__ == '__main__':
     app = QApplication(sys.argv)
     filedlg = QFileDialog()
-    filedlg.setFileMode(QFileDialog.FileMode.DirectoryOnly)
+    filedlg.setFileMode(QFileDialog.FileMode.Directory)
+    filedlg.setOption(QFileDialog.Option.ShowDirsOnly)
     filename = str(filedlg.getExistingDirectory(None,
                                                 'Open Folder'))
     tags = []

--- a/puddlestuff/mainwin/artwork.py
+++ b/puddlestuff/mainwin/artwork.py
@@ -19,8 +19,7 @@ def svg_to_pic(data, desc):
 
 def get_font(rect, *text):
     font = QFont()
-    metrics = QFontMetrics
-    lengths = [(t, metrics(font).width(t)) for t in text]
+    lengths = [(t, QFontMetrics(font).horizontalAdvance(t)) for t in text]
     lowest = max(lengths, key=lambda x: x[1])
     size = 12
     while QFontMetrics(font).width(lowest[0]) < rect.width() - 30:

--- a/puddlestuff/mainwin/dirview.py
+++ b/puddlestuff/mainwin/dirview.py
@@ -2,7 +2,7 @@ import os
 
 from PyQt5.QtCore import QDir, QItemSelectionModel, QMutex, QSettings, QUrl, Qt, pyqtSignal
 from PyQt5.QtGui import QDesktopServices
-from PyQt5.QtWidgets import QAbstractItemView, QAction, QCheckBox, QDirModel, QHeaderView, QMenu, QTreeView, QVBoxLayout, QWidget
+from PyQt5.QtWidgets import QAbstractItemView, QAction, QCheckBox, QFileSystemModel, QHeaderView, QMenu, QTreeView, QVBoxLayout, QWidget
 
 from ..constants import LEFTDOCK, QT_CONFIG
 from ..puddleobjects import (PuddleConfig, PuddleThread,
@@ -26,17 +26,15 @@ class DirView(QTreeView):
         self._load = False  # If True a loadFiles signal is emitted when
         # an index is clicked. See selectionChanged.
 
-        dirmodel = QDirModel()
-        dirmodel.setSorting(QDir.SortFlag.IgnoreCase)
-        dirmodel.setFilter(QDir.Filter.Dirs | QDir.Filter.NoDotAndDotDot)
-        dirmodel.setReadOnly(False)
-        dirmodel.setLazyChildCount(False)
-        dirmodel.setResolveSymlinks(False)
+        model = QFileSystemModel()
+        model.setRootPath('/')
+        model.setFilter(QDir.Filter.Dirs | QDir.Filter.NoDotAndDotDot)
+        model.setReadOnly(False)
         header = PuddleHeader(Qt.Orientation.Horizontal, self)
         self.setHeader(header)
         self.header().setSectionResizeMode(QHeaderView.ResizeMode.ResizeToContents)
 
-        self.setModel(dirmodel)
+        self.setModel(model)
         [self.hideColumn(column) for column in range(1, 4)]
 
         self.header().hide()

--- a/puddlestuff/mainwin/filterwin.py
+++ b/puddlestuff/mainwin/filterwin.py
@@ -53,7 +53,7 @@ class FilterView(QWidget):
             str(edit.text()))
         go_button.clicked.connect(emit_filter)
         edit.returnPressed.connect(emit_filter)
-        self.combo.combo.activated.connect(
+        self.combo.combo.textActivated.connect(
             lambda i: emit_filter())
 
     def saveSettings(self):

--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -2266,7 +2266,7 @@ class PuddleCombo(QWidget):
         hbox = QHBoxLayout()
         hbox.setContentsMargins(0, 0, 0, 0)
         self.combo = QComboBox()
-        self.combo.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToMinimumContentsLength)
+        self.combo.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToContents)
 
         self.remove = QToolButton()
         self.remove.setIcon(get_icon('list-remove', ':/remove.png'))

--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -20,9 +20,9 @@ from itertools import groupby  # for unique function.
 from PyQt5.QtCore import QBuffer, QByteArray, QDir, QRectF, QSettings, QSize, QThread, QTimer, Qt, pyqtSignal
 from PyQt5.QtCore import QFile, QIODevice
 from PyQt5.QtGui import QIcon, QBrush, QPixmap, QImage, \
-    QKeySequence
+    QKeySequence, QScreen
 from PyQt5.QtSvg import QGraphicsSvgItem, QSvgRenderer
-from PyQt5.QtWidgets import QAbstractItemView, QAction, QApplication, QComboBox, QDesktopWidget, QDialog, QDialogButtonBox, \
+from PyQt5.QtWidgets import QAbstractItemView, QAction, QApplication, QComboBox, QDialog, QDialogButtonBox, \
     QDockWidget, QFileDialog, QFrame, QGraphicsPixmapItem, QGraphicsScene, QGraphicsView, QGridLayout, QHBoxLayout, \
     QHeaderView, QLabel, QLayout, QLineEdit, QListWidget, QMenu, QMessageBox, QProgressBar, QPushButton, QSizePolicy, \
     QTextEdit, QToolButton, QVBoxLayout, QWidget
@@ -2157,7 +2157,7 @@ class PicWin(QDialog):
         self.label.clicked.connect(self.close)
 
     def setImage(self, pixmap):
-        maxsize = QDesktopWidget().availableGeometry().size()
+        maxsize = QScreen().availableGeometry().size()
         self.label.setPixmap(pixmap)
         if hasattr(pixmap, 'size'):
             size = pixmap.size()

--- a/puddlestuff/puddletag.py
+++ b/puddlestuff/puddletag.py
@@ -450,7 +450,8 @@ class MainWin(QMainWindow):
     def _getDir(self):
         dirname = self._lastdir[0] if self._lastdir else QDir.homePath()
         filedlg = QFileDialog()
-        filedlg.setFileMode(QFileDialog.FileMode.DirectoryOnly)
+        filedlg.setFileMode(QFileDialog.FileMode.Directory)
+        filedlg.setOption(QFileDialog.Option.ShowDirsOnly)
         filename = str(QFileDialog.getExistingDirectory(self,
                                                         translate("Main Window", 'Import directory...'),
                                                         dirname,

--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -719,7 +719,7 @@ class TagModel(QAbstractTableModel):
                     tooltip = val
                 return tooltip
             return val
-        elif role == Qt.ItemDataRole.BackgroundColorRole:
+        elif role == Qt.ItemDataRole.BackgroundRole:
             audio = self.taginfo[row]
             if audio.color:
                 return audio.color

--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -2,6 +2,7 @@ import os
 import re
 import sys
 import time
+from contextlib import contextmanager
 from copy import copy, deepcopy
 from operator import itemgetter
 from os import path
@@ -513,20 +514,20 @@ class TagModel(QAbstractTableModel):
         self.reverseSort = True
         self._savedundolevel = None
 
-        if taginfo is not None:
-            self.taginfo = unique(taginfo)
-            self.sortByFields(self.sortFields, reverse=self.reverseSort)
-        else:
-            self.taginfo = []
-            self.reset()
-        for z in self.taginfo:
-            z.preview = {}
-            z.previewundo = {}
-            z.undo = {}
-            z.color = None
-            z._temp = {}
-            if not hasattr(z, 'library'):
-                z.library = None
+        with self.reset_context():
+            if taginfo is not None:
+                self.taginfo = unique(taginfo)
+                self.sortByFields(self.sortFields, reverse=self.reverseSort)
+            else:
+                self.taginfo = []
+            for z in self.taginfo:
+                z.preview = {}
+                z.previewundo = {}
+                z.undo = {}
+                z.color = None
+                z._temp = {}
+                if not hasattr(z, 'library'):
+                    z.library = None
         self.undolevel = 0
         self._fontSize = QFont().pointSize()
 
@@ -636,19 +637,18 @@ class TagModel(QAbstractTableModel):
             self._undo[self.undolevel][audio] = undo
 
     def applyFilter(self, pattern=None, matchcase=True):
-        self.taginfo = self.taginfo + self._filtered
-        taginfo = self.taginfo
-        if (not pattern) and (not self._filtered):
-            return
-        elif not pattern:
-            self._filtered = []
-            self.reset()
-            return
+        with self.reset_context():
+            self.taginfo = self.taginfo + self._filtered
+            taginfo = self.taginfo
+            if (not pattern) and (not self._filtered):
+                return
+            elif not pattern:
+                self._filtered = []
+                return
 
-        filtered = [(filter_audio(a, pattern), a) for a in self.taginfo]
-        self._filtered = [z[1] for z in filtered if not z[0]]
-        self.taginfo = [z[1] for z in filtered if z[0]]
-        self.reset()
+            filtered = [(filter_audio(a, pattern), a) for a in self.taginfo]
+            self._filtered = [z[1] for z in filtered if not z[0]]
+            self.taginfo = [z[1] for z in filtered if z[0]]
 
     def changeFolder(self, olddir, newdir):
         """Used for changing the directory of all the files in olddir to newdir.
@@ -811,7 +811,6 @@ class TagModel(QAbstractTableModel):
         else:
             self.headerdata += [("", "") for z in range(count - column + 1)]
         self.endInsertColumns()
-        # self.modelReset.emit() #Because of the strange behaviour mentioned in reset.
         return True
 
     def reloadTags(self, tags):
@@ -873,10 +872,9 @@ class TagModel(QAbstractTableModel):
             bottom = self.index(self.rowCount() - 1, self.columnCount() - 1)
             self.dataChanged.emit(top, bottom)
         else:
-            top = self.index(0, 0)
-            self.taginfo = taginfo
-            self._filtered = []
-            self.reset()
+            with self.reset_context():
+                self.taginfo = taginfo
+                self._filtered = []
             self.sortByFields(self.sortFields, reverse=self.reverseSort)
             [setattr(z, 'color', None) for z in self.taginfo if z.color]
             self.undolevel = 0
@@ -982,15 +980,13 @@ class TagModel(QAbstractTableModel):
         self.endRemoveRows()
         return True
 
-    def reset(self):
-        # Sometimes, (actually all the time on my box, but it may be different on yours)
-        # if a number files loaded into the model is equal to number
-        # of files currently in the model then the TableView isn't updated.
-        # Why the fuck I don't know, but this signal, intercepted by the table,
-        # updates the view and makes everything work okay.
+    @contextmanager
+    def reset_context(self):
         self.beginResetModel()
-        self.modelReset.emit()
-        self.endResetModel()
+        try:
+            yield None
+        finally:
+            self.endResetModel()
 
     def rowColors(self, rows=None, clear=False):
         """Changes the background of rows to green.
@@ -1063,10 +1059,10 @@ class TagModel(QAbstractTableModel):
         self.headerDataChanged.emit(orientation, section, section)
 
     def setHeader(self, tags):
-        self.headerdata = tags
-        self.headerDataChanged.emit(
-            Qt.Orientation.Horizontal, 0, len(self.headerdata))
-        self.reset()
+        with self.reset_context():
+            self.headerdata = tags
+            self.headerDataChanged.emit(
+                Qt.Orientation.Horizontal, 0, len(self.headerdata))
 
     def setRowData(self, row, tags, undo=False, justrename=False, temp=False):
         """A function to update one row.
@@ -1173,18 +1169,19 @@ class TagModel(QAbstractTableModel):
         elif reverse is None:
             reverse = False
 
-        if files and rows:
-            for field in fields:
-                files.sort(key=lambda a: natural_sort_key(a.get(field, '')), reverse=reverse)
-            for index, row in enumerate(rows):
-                self.taginfo[row] = files[index]
-        else:
-            for field in fields:
-                self.taginfo.sort(key=lambda a: natural_sort_key(a.get(field, '')), reverse=reverse)
+        with self.reset_context():
+            if files and rows:
+                for field in fields:
+                    files.sort(key=lambda a: natural_sort_key(a.get(field, '')), reverse=reverse)
+                for index, row in enumerate(rows):
+                    self.taginfo[row] = files[index]
+            else:
+                for field in fields:
+                    self.taginfo.sort(key=lambda a: natural_sort_key(a.get(field, '')), reverse=reverse)
 
-        self.reverseSort = reverse
-        self.sortFields = fields
-        self.reset()
+            self.reverseSort = reverse
+            self.sortFields = fields
+
         self.sorted.emit()
 
     def supportedDropActions(self):
@@ -1548,8 +1545,8 @@ class TagTable(QTableView):
             self.model().changeFolder(olddir, newdir)
 
     def clearAll(self):
-        self.model().taginfo = []
-        self.model().reset()
+        with self.model().reset_context():
+            self.model().taginfo = []
         self.dirschanged.emit([])
 
     def _closeEditor(self, editor, hint=QAbstractItemDelegate.EndEditHint.NoHint):
@@ -1933,7 +1930,6 @@ class TagTable(QTableView):
         start_index = model.index(0, 0)
         end_index = model.index(model.rowCount() - 1, model.columnCount() - 1)
         model.dataChanged.emit(start_index, end_index)
-        # model.reset()
         self.selectionChanged()
 
     def load_tags(self, tags):
@@ -2083,10 +2079,11 @@ class TagTable(QTableView):
         new_fns = set(z.filepath for z in tags)
         to_remove = set(z for z in sub_files
                         if z.filepath not in new_fns)
-        self.model().taginfo = [z for z in self.model().taginfo if
-                                z not in to_remove]
-        self.fillTable(tags, None)
-        model = self.model().reset()
+        with self.model().reset_context():
+            self.model().taginfo = [z for z in self.model().taginfo if
+                                    z not in to_remove]
+            self.fillTable(tags, None)
+
         self.filesloaded.emit(True)
         if self._restore:
             self.restoreSelection(self._restore)

--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -1938,7 +1938,7 @@ class TagTable(QTableView):
         self.dirschanged.emit(self.dirs[::])
         self.filesloaded.emit(True)
         sortcolumn = self.horizontalHeader().sortIndicatorSection()
-        QTableView.sortByColumn(self, sortcolumn)
+        QTableView.sortByColumn(self, sortcolumn, Qt.SortOrder.AscendingOrder)
 
     def loadSettings(self):
         (tags, fontsize, rowsize, self.filespec) = loadsettings()
@@ -2468,9 +2468,9 @@ class TagTable(QTableView):
         else:
             self.model().setTestData(self.selectedRows, data)
 
-    def sortByColumn(self, column):
+    def sortByColumn(self, column, order):
         """Guess"""
-        QTableView.sortByColumn(self, column)
+        QTableView.sortByColumn(self, column, order)
         self.restoreSelection()
 
     def wheelEvent(self, e):


### PR DESCRIPTION
As with every major/minor release, Qt5 and subsequently PyQt5 obsoleted/deprecated a few things (classes, methods, properties, ...) which will be removed with Qt6 and PyQt6. This PR replaces all these obsoleted/deprecated things with their "modern" pendant to future-proof, and preempt instant breakage when moving to PyQt6.