### PR TITLE
Bugfix/dirview

### DIFF
--- a/puddlestuff/mainwin/dirview.py
+++ b/puddlestuff/mainwin/dirview.py
@@ -90,7 +90,7 @@ class DirView(QTreeView):
                                     'Refresh Directory'), self)
 
         index = self.indexAt(event.pos())
-        connect(refresh, lambda: self.model().refresh(index))
+        connect(refresh, lambda: self.model().fetchMore(index))
 
         header = self.header()
         if self.header().isHidden():
@@ -135,7 +135,7 @@ class DirView(QTreeView):
                 while not i.isValid():
                     p = os.path.dirname(p)
                     i = getindex(p)
-                model.refresh(i)
+                model.fetchMore(i)
 
         for d in [z[1] for z in dirs] + selected:
             self.selectIndex(getindex(d))


### PR DESCRIPTION
## Fix dirview refresh

In contrast to the old QDirModel, the new QFileSystemModel automatically detects changes in the filesystem and updates itself. Because of that a refresh is technically not needed, or even possible. But you never know, so we keep it for now and call `fetchMore(QModelIndex)` instead which should do something similar.

Fixes #708

## Hide expand arrow on empty folder

Hide the little expand arrow on folders that do not have subfolders. Unfortunately does the `QDir.Filter.Dirs` filter not do this, we need to do it ourselfs. Solution was shamelessly plugged from [here](https://stackoverflow.com/a/18007243/1094486).