### PR TITLE
Restore Qt5 LTS compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,16 @@ Then:
 ```
 git clone https://github.com/puddletag/puddletag
 cd puddletag
-PYTHONPATH=source/ ./source/puddletag
+./puddletag
+```
+
+Alternatively you can use a [virtual environment](https://docs.python.org/3/library/venv.html), which only requires python and pip to be installed:
+```sh
+git clone 'https://github.com/puddletag/puddletag.git'
+cd 'puddletag'
+python3 -m 'venv' '.'
+bin/pip3 install -r 'requirements.txt'
+bin/python3 'puddletag'
 ```
 </details>
 

--- a/puddlestuff/mainwin/filterwin.py
+++ b/puddlestuff/mainwin/filterwin.py
@@ -53,7 +53,7 @@ class FilterView(QWidget):
             str(edit.text()))
         go_button.clicked.connect(emit_filter)
         edit.returnPressed.connect(emit_filter)
-        self.combo.combo.textActivated.connect(
+        self.combo.combo.activated.connect(
             lambda i: emit_filter())
 
     def saveSettings(self):


### PR DESCRIPTION
Restore the unintentionally broken backwards-compatibility for Qt 5.12, which was the last LTS version. I double-checked #705, and this was the only breaking change.