### PR TITLE
Report problems from the app

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -31,7 +31,7 @@ body:
     description: |
       Describe what you did to run into the problem.
 
-      Be as detailed as possible. Attach a sample-file if useful.
+      Be as detailed as possible. Attach a sample-file if useful, put it in a ZIP-Archive if GitHub does not allow to attach it directly.
     placeholder: |
       1. Open file `sample.mp3`
       2. Click button `Update`

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,64 @@
+---
+name: Bug report
+description: Report a problem with the application
+labels: ['bug']
+body:
+- id: current
+  type: textarea
+  validations:
+    required: true
+  attributes:
+    label: Current Behavior
+    description: |
+      Describe what you're experiencing.
+
+      Be as detailed as possible. Run the application from a terminal to see errors and details. Include any error message in its entirety, preferably as text in a code block. Use screenshots if you think it helps.
+
+      Tip: You can attach images or log files by clicking an textarea to highlight it and then dragging files in.
+- id: expected
+  type: textarea
+  validations:
+    required: true
+  attributes:
+    label: Expected Behavior
+    description: Describe what you expected to happen.
+- id: reproduce
+  type: textarea
+  validations:
+    required: true
+  attributes:
+    label: Steps To Reproduce
+    description: |
+      Describe what you did to run into the problem.
+
+      Be as detailed as possible. Attach a sample-file if useful.
+    placeholder: |
+      1. Open file `sample.mp3`
+      2. Click button `Update`
+      3. Run function `format` with parameter `title`
+- id: system
+  type: textarea
+  validations:
+    required: true
+  attributes:
+    label: Information about your system
+    description: |
+      Describe your system and the environment you run the application in.
+
+      Example:
+        Puddletag: 2.0.1
+        OS: Ubuntu 20.04
+        Python: 13.14.0
+        PyQt: 7.6.3
+    value: |-
+      Puddletag: 
+      OS: 
+      Python: 
+      PyQt: 
+- id: additional
+  type: textarea
+  attributes:
+    label: Anything else?
+    description: |
+      Got some Links or References? Anything that did not fit anywhere above but will give us more context about the problem you are encountering.
+      Or a cute animal picture, they are always welcome.

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -50,6 +50,8 @@ body:
         OS: Ubuntu 20.04
         Python: 13.14.0
         PyQt: 7.6.3
+
+      Tip: This section is automatically filled when using the "Report a problem" function in the "Help" menu of the application.
     value: |-
       Puddletag: 
       OS: 

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -12,7 +12,7 @@ body:
     description: |
       Describe the problem you are trying to solve. What would it make possible or easier?
 
-      Tip: You can attach images or files by clicking an textarea to highlight it and then dragging files in.
+      Tip: You can attach images or files by clicking an textarea to highlight it and then dragging files in. Put them in a ZIP-Archive if GitHub does not allow to attach them directly.
 - id: solution
   type: textarea
   validations:

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,38 @@
+---
+name: Feature request
+description: Suggest an idea for the application
+labels: ['feature-request']
+body:
+- id: idea
+  type: textarea
+  validations:
+    required: true
+  attributes:
+    label: What's missing?
+    description: |
+      Describe the problem you are trying to solve. What would it make possible or easier?
+
+      Tip: You can attach images or files by clicking an textarea to highlight it and then dragging files in.
+- id: solution
+  type: textarea
+  validations:
+    required: true
+  attributes:
+    label: Your solution
+    description: |
+      Describe your solution. What needs to change? How do you imagine it will work? Add screenshots if you think it helps.
+- id: alternative
+  type: textarea
+  validations:
+    required: true
+  attributes:
+    label: Any alternatives?
+    description: |
+      Are there any alternative solutions or approaches you have considered?
+- id: additional
+  type: textarea
+  attributes:
+    label: Anything else?
+    description: |
+      Got some Links or References? Anything that did not fit anywhere above but will give us more context about your idea.
+      Or a cute animal picture, they are always welcome.

--- a/puddlestuff/puddletag.py
+++ b/puddlestuff/puddletag.py
@@ -290,6 +290,7 @@ def create_bug_report_issue():
 
     params = urllib.parse.urlencode({
         'template': 'bug_report.yaml',
+        'labels': 'bug',
         'system': '\n'.join(map(lambda x: f'{x[0]}: {x[1]}', version_list)),
     })
     url = f'https://github.com/puddletag/puddletag/issues/new?{params}'


### PR DESCRIPTION
## Add issue templates
Add two purpose-build templates for bug reports and feature request. Those will hopefully give users some handrails and structure to improve issue quality. They are based on the default that GitHub provides, but extended/reworded to fit better.
I am deliberately not using the markdown templates but the [new yaml-based issue forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms). While they are still in beta, they have the distinct advantage of being more flexible and allow better structure, and also make it possible to pre-fill the separate parts individually with [query parameters](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-an-issue#creating-an-issue-from-a-url-query). This allows us to pre-fill the technical part without duplicating the whole issue template.

These should™ be used as soon the PR is merged into `master`, no further configuration needed.

## Rewire menu item to issue template
Instead of adding a new menu item I repurposed the existing "Bug tracker" one, because right above it is the GitHub link/item and it is common enough that you can assume a project hosted on GitHub will use its issue system as bug tracker.
It amazes me that you need a 79 line function only to reliably get a useful linux distribution name across a range of python versions. Not really sure what all that up and down in the platform module is about.

Closes #552