### PR TITLE
added unidecode function for converting unicode to ascii

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ _support needed, open an issue if interested in working on it_
 <summary><b>Source code</b></summary>
 First, you need to install the dependencies; this step is different depending on the distribution; on Debian you can run:
 
-`apt install python3 python3-mutagen python3-configobj python3-pyparsing python3-pyqt5 python3-pyqt5.qtsvg`
+`apt install python3 python3-mutagen python3-configobj python3-pyparsing python3-pyqt5 python3-pyqt5.qtsvg python3-unidecode`
 
 Then:
 

--- a/docs/_sources/source/scripting.txt
+++ b/docs/_sources/source/scripting.txt
@@ -199,7 +199,7 @@ The scripting functions that puddletag supports are listed here. Use them where 
 
 .. describe:: $deunicode(x)
 
-   Converts all unicode chars in x to ASCII using unidecode eg. 'é' will become 'e'.
+   Converts all unicode chars in x to ASCII using transliteration, e.g. 'abc äéç цы キウ 藏經' will become 'abc aec tsy kiu Cang Jing '.
 
 
 .. describe:: $upper(string)

--- a/docs/_sources/source/scripting.txt
+++ b/docs/_sources/source/scripting.txt
@@ -33,6 +33,7 @@ The scripting functions that puddletag supports are listed here. Use them where 
 .. describe:: $caps3(string)
 
    Capitalizes the first letter of the string and converts the rest to lower case.
+
    
 .. describe:: $ceiling(number)
 
@@ -170,6 +171,7 @@ The scripting functions that puddletag supports are listed here. Use them where 
 
    For the floating point number x.y. Returns the integer x if y < 0.5 else x + 1.
 
+
 .. describe:: $replace(string, word, replaceword, matchcase, whole)
 
    Replaces word in string with replaceword. If matchcase is true, a case-sensitive replace is done. Whole is true implies that only whole word matches are replaced.
@@ -193,6 +195,11 @@ The scripting functions that puddletag supports are listed here. Use them where 
 .. describe:: $to_ascii(x)
 
    Converts all unicode chars in x to ASCII eg. 'é' will become 'e'. Characters that can't be converted will be removed.
+
+
+.. describe:: $deunicode(x)
+
+   Converts all unicode chars in x to ASCII using unidecode eg. 'é' will become 'e'.
 
 
 .. describe:: $upper(string)

--- a/docs/source/scripting.html
+++ b/docs/source/scripting.html
@@ -323,6 +323,12 @@
 
 <dl class="describe">
 <dt>
+<code class="sig-name descname">$deunicode(x)</code></dt>
+<dd><p>Converts all unicode chars in x to ASCII using unidecode eg. 'é' will become 'e'.</p>
+</dd></dl>
+
+<dl class="describe">
+<dt>
 <code class="sig-name descname">$upper(string)</code></dt>
 <dd><p>Converts string to uppercase.</p>
 </dd></dl>

--- a/docsrc/source/scripting.txt
+++ b/docsrc/source/scripting.txt
@@ -33,6 +33,7 @@ The scripting functions that puddletag supports are listed here. Use them where 
 .. describe:: $caps3(string)
 
    Capitalizes the first letter of the string and converts the rest to lower case.
+
    
 .. describe:: $ceiling(number)
 
@@ -75,6 +76,7 @@ The scripting functions that puddletag supports are listed here. Use them where 
 .. describe:: $isdigit(x)
 
    Returns true if x is a decimal number.
+
 
 .. describe:: $left(string, n)
 
@@ -154,6 +156,7 @@ The scripting functions that puddletag supports are listed here. Use them where 
 
    Generates a pseudo-random number between 0 and 1.
 
+
 .. describe:: $regex(text, regex, repl, matchcase=0)
 
    Replaces all occurrences of **regex** with **repl** in text.
@@ -169,6 +172,7 @@ The scripting functions that puddletag supports are listed here. Use them where 
 .. describe:: $round()
 
    For the floating point number x.y. Returns the integer x if y < 0.5 else x + 1.
+
 
 .. describe:: $replace(string, word, replaceword, matchcase, whole)
 
@@ -193,6 +197,11 @@ The scripting functions that puddletag supports are listed here. Use them where 
 .. describe:: $to_ascii(x)
 
    Converts all unicode chars in x to ASCII eg. 'é' will become 'e'. Characters that can't be converted will be removed.
+
+
+.. describe:: $deunicode(x)
+
+   Converts all unicode chars in x to ASCII using unidecode eg. 'é' will become 'e'.
 
 
 .. describe:: $upper(string)

--- a/puddlestuff/about.py
+++ b/puddlestuff/about.py
@@ -65,6 +65,7 @@ def versions():
         'audioread': get_module_version('audioread'),
         'Levenshtein': get_module_version('Levenshtein'),
         'Chromaprint': get_module_version('chromaprint'),
+        'Unidecode': get_module_version('Unidecode'),
     }
 
 

--- a/puddlestuff/functions.py
+++ b/puddlestuff/functions.py
@@ -43,6 +43,7 @@ import unicodedata
 from mutagen.mp3 import HeaderNotFoundError
 from collections import defaultdict
 from functools import partial
+from unidecode import unidecode
 
 import pyparsing
 
@@ -769,6 +770,10 @@ def to_ascii(t_fn):
     cleaned_fn = unicodedata.normalize('NFKD', t_fn).encode('ASCII', 'ignore')
     return ''.join(chr(c) for c in cleaned_fn if chr(c) in VALID_FILENAME_CHARS)
 
+# hack by David Gessel
+def deunicode(text):
+    dutext = unidecode(text)
+    return (dutext)
 
 def remove_dupes(m_text, matchcase=False):
     """Remove duplicate values, "Remove Dupes: $0, Match Case $1"
@@ -1126,7 +1131,8 @@ functions = {
     'update_from_tag': update_from_tag,
     "validate": validate,
     'to_ascii': to_ascii,
-    'to_num': to_num
+    'to_num': to_num,
+    'deunicode': deunicode
 }
 
 no_fields = [filenametotag, load_images, move, remove_except,

--- a/requirements.in
+++ b/requirements.in
@@ -3,6 +3,7 @@ pyqt5==5.15.7
 configobj==5.0.6
 mutagen==1.45.1
 pyparsing==3.0.9
+unidecode==1.0.22
 
 # extra / tag sources
 lxml==4.9.0

--- a/requirements.in
+++ b/requirements.in
@@ -3,7 +3,7 @@ pyqt5==5.15.7
 configobj==5.0.6
 mutagen==1.45.1
 pyparsing==3.0.9
-unidecode==1.0.22
+unidecode==1.3.6
 
 # extra / tag sources
 lxml==4.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,3 +42,5 @@ six==1.16.0
     # via configobj
 urllib3==1.26.8
     # via requests
+unidecode==1.0.22
+    # via -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,5 +42,5 @@ six==1.16.0
     # via configobj
 urllib3==1.26.8
     # via requests
-unidecode==1.0.22
+unidecode==1.3.6
     # via -r requirements.in


### PR DESCRIPTION
$to_ascii results in null output for a lot of tag conversions from UTF8 multi-lingual to ASCII (for filenames). Testing with Unidecode 1.3.4 yielded very reasonable results.

For example $to_ascii(%title%) where title is "Моя цыганиада" returns "( )" I'm not sure why the "(" are being inserted around the space, but none of the UTF8 characters are converted.

unidecode does very well:

$ unidecode -c "Моя цыганиада"
Moia tsyganiada

Another example: $to_ascii converts "ウ・キ・ウ・キ★ミッドナイト"
to ""

while
$ unidecode -c "ウ・キ・ウ・キ★ミッドナイト"
ukiukimitsudonaito

Unidecode yields very useful results that meet the expectations while the current implementation of $to_ascii does not.