### PR TITLE
fix __reference_time global variable error in discogs.py

### DIFF
--- a/puddlestuff/tagsources/discogs.py
+++ b/puddlestuff/tagsources/discogs.py
@@ -239,6 +239,7 @@ def retrieve_album(info, image=LARGEIMAGE, rls_type=None):
 
 
 def urlopen(url):
+    global __reference_time
     url = iri_to_uri(url)
     request = urllib.request.Request(url)
     request.add_header('Accept-Encoding', 'gzip')


### PR DESCRIPTION
#### Reference issue
Fixes #755 

#### Changes
In [puddletag/puddlestuff/tagsources/discogs.py](https://github.com/puddletag/puddletag/blob/master/puddlestuff/tagsources/discogs.py), add `global __reference_time` in `urlopen()` function definition (line 242)