### PR TITLE
Fix window icon under Wayland

### DIFF
--- a/puddletag
+++ b/puddletag
@@ -353,6 +353,7 @@ if __name__ == '__main__':
     from puddlestuff.puddlesettings import load_gen_settings
 
     app.setWindowIcon(QIcon(":/appicon.svg"))
+    app.setDesktopFileName("puddletag.desktop")
     app.setOrganizationName("Puddle Inc.")
     app.setApplicationName("puddletag")
 


### PR DESCRIPTION
Contrary to X11, with Wayland a app/window is no longer able to directly provide a window icon as a bitmap. Instead it will look up the `.desktop` file and use its `Icon=` value (if any). The desktop file name, if not explicitly defined, is determined from the name of the executable; in case of python apps like puddletag this is `python3`. To make it use the right one, simply explicitly set the desktop file name.

This has another downside: The `.desktop` files are only searched in specific directories. If you run puddletag straight from git/source, the desktop file won't be in a directory that will be searched in, and the icon will still be missing. Oh, brave new world.