### PR TITLE
Fix image mimetype

### DIFF
--- a/puddlestuff/audioinfo/mp4.py
+++ b/puddlestuff/audioinfo/mp4.py
@@ -1,4 +1,3 @@
-import imghdr
 from copy import deepcopy
 
 from mutagen.mp4 import MP4, MP4Cover
@@ -7,7 +6,7 @@ from . import tag_versions, util
 from .util import (usertags, isempty,
                    FILENAME, PATH,
                    getdeco, setdeco, FILETAGS, str_filesize, fn_hash, CaselessDict, keys_deco,
-                   del_deco, cover_info, info_to_dict, parse_image, get_total)
+                   del_deco, cover_info, info_to_dict, parse_image, get_total, get_mime)
 
 ATTRIBUTES = ('frequency', 'bitrate', 'length', 'accessed', 'size', 'created',
               'modified', 'bitspersample', 'channels')
@@ -171,10 +170,10 @@ def bin_to_pic(cover):
 
 def pic_to_bin(image):
     data = image[util.DATA]
-    mime = imghdr.what(None, data)
-    if mime == 'png':
+    mime = get_mime(data)
+    if mime == 'image/png':
         format = MP4Cover.FORMAT_PNG
-    elif mime == 'jpeg':
+    elif mime == 'image/jpeg':
         format = MP4Cover.FORMAT_JPEG
     else:
         return

--- a/puddlestuff/audioinfo/util.py
+++ b/puddlestuff/audioinfo/util.py
@@ -1,6 +1,5 @@
 import base64
 import calendar
-import imghdr
 import logging
 import os
 import sys
@@ -11,6 +10,7 @@ from errno import ENOENT
 from os import path, stat
 
 import mutagen
+from PyQt5.QtCore import QMimeDatabase
 
 from .constants import *
 
@@ -258,14 +258,13 @@ def getinfo(filename):
 
 
 def get_mime(data):
-    """Retrieve the mimetype of the image, data (a bytestring).
+    """Retrieve the mimetype of the image data (a bytes object).
 
     Returns either 'image/jpeg', 'image/png' or ''."""
-    mime = imghdr.what(None, data)
-    if mime:
-        return 'image/' + mime
-    else:
-        return ''
+    mime = QMimeDatabase().mimeTypeForData(data)
+    if not mime.isDefault():
+        return mime.name()
+    return ''
 
 
 def get_total(tag):
@@ -443,8 +442,7 @@ def path_to_string(value):
 
 _image_defaults = {
     DESCRIPTION: lambda i: i.get(DESCRIPTION, ''),
-    MIMETYPE: lambda i: get_mime(i[DATA]) if MIMETYPE in i else \
-        get_mime(i[DATA]),
+    MIMETYPE: lambda i: i.get(MIMETYPE, None) or get_mime(i[DATA]),
     IMAGETYPE: lambda i: i.get(IMAGETYPE, DEFAULT_COVER),
     DATA: lambda i: i[DATA]}
 

--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -30,7 +30,7 @@ from configobj import ConfigObjError
 
 from . import audioinfo
 from .audioinfo import (IMAGETYPES, DESCRIPTION, DATA, IMAGETYPE, DEFAULT_COVER,
-                        INFOTAGS)
+                        INFOTAGS, get_mime)
 from .constants import ACTIONDIR, SAVEDIR, CONFIGDIR
 from .translations import translate
 
@@ -1852,7 +1852,7 @@ class PicWidget(QWidget):
                 "height": image.height(),
                 "width": image.width(),
                 "size": len(data),
-                "mime": "image/jpeg",
+                "mime": get_mime(data),
                 "description": "",
                 "imagetype": 3
             }
@@ -2085,7 +2085,7 @@ class PicWidget(QWidget):
             if image.loadFromData(data):
                 pic = {'data': data, 'height': image.height(),
                        'width': image.width(), 'size': len(data),
-                       'mime': 'image/jpeg',
+                       'mime': get_mime(data),
                        'description': "",
                        'imagetype': 3}
                 images.append(pic)
@@ -2098,7 +2098,7 @@ class PicWidget(QWidget):
             image = QImage().fromData(d)
             pic = {'data': d, 'height': image.height(),
                    'width': image.width(), 'size': len(data),
-                   'mime': 'image/jpeg',
+                   'mime': get_mime(d),
                    'description': "",
                    'imagetype': 3}
             images.append(pic)


### PR DESCRIPTION
Replace the now deprecated imghdr module with QMimeDatabase, and also remove any hardcoded mimetype setting with a proper detection.

Fixes #786