### PR TITLE
Improve natural sorting

### DIFF
--- a/puddlestuff/functions.py
+++ b/puddlestuff/functions.py
@@ -48,7 +48,7 @@ import pyparsing
 
 from . import audioinfo
 from .audioinfo import encode_fn
-from .puddleobjects import (safe_name, fnmatch, natsort_case_key)
+from .puddleobjects import (safe_name, fnmatch, natural_sort_key)
 
 PATH = audioinfo.PATH
 DIRPATH = audioinfo.DIRPATH
@@ -905,16 +905,12 @@ def sort_field(m_text, order='Ascending', matchcase=False):
 &Order, combo, Ascending, Descending,
 Match &Case, check"""
     text = m_text
-    if not matchcase:
-        key = natsort_case_key
-    else:
-        key = None
+
     if isinstance(text, str):
         return text
-    if order == 'Ascending':
-        return sorted(text, key=key)
-    else:
-        return sorted(text, key=key, reverse=True)
+    return sorted(text,
+                  key=lambda x: natural_sort_key(x, case_insensitive=not matchcase),
+                  reverse=order != 'Ascending')
 
 
 def split_by_sep(m_text, sep):

--- a/puddlestuff/helperwin.py
+++ b/puddlestuff/helperwin.py
@@ -17,7 +17,7 @@ from .constants import HOMEDIR, KEEP
 from .puddleobjects import (
     get_icon, gettaglist, partial,
     settaglist, winsettings, ListButtons, MoveButtons, OKCancel,
-    PicWidget, PuddleConfig, natsort_case_key)
+    PicWidget, PuddleConfig, natural_sort_key)
 from .translations import translate
 from .util import pprint_tag
 from .util import to_string
@@ -518,7 +518,7 @@ class StatusWidgetCombo(QComboBox):
         self.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToContents)
 
         items = map(str, items)
-        items = sorted(items, key=natsort_case_key)
+        items = sorted(items, key=natural_sort_key)
         if len(items) > 1:
             items.append(r'\\'.join(items))
         self.addItem(KEEP)

--- a/puddlestuff/masstag/__init__.py
+++ b/puddlestuff/masstag/__init__.py
@@ -5,7 +5,7 @@ from operator import itemgetter
 from ..audioinfo import FILENAME
 from ..constants import VARIOUS
 from ..findfunc import filenametotag
-from ..puddleobjects import natsort_case_key, ratio
+from ..puddleobjects import natural_sort_key, ratio
 from ..tagsources import RetrievalError
 from ..translations import translate
 from ..util import sorted_split_by_field, split_by_field, to_string
@@ -111,11 +111,8 @@ class MassTagFlag(object):
 def brute_force_results(audios, retrieved):
     matched = {}
 
-    audios = sorted(audios, natsort_case_key,
-                    lambda f: to_string(f.get('track', f['__filename'])))
-
-    retrieved = sorted(retrieved, natsort_case_key,
-                       lambda t: to_string(t.get('track', t.get('title', ''))))
+    audios = sorted(audios, key=lambda f: natural_sort_key(to_string(f.get('track', f['__filename']))))
+    retrieved = sorted(retrieved, key=lambda t: natural_sort_key(to_string(t.get('track', t.get('title', '')))))
 
     for audio, result in zip(audios, retrieved):
         matched[audio] = result

--- a/puddlestuff/plugins/view_all_fields/__init__.py
+++ b/puddlestuff/plugins/view_all_fields/__init__.py
@@ -7,7 +7,7 @@ from PyQt5.QtWidgets import QAbstractItemView, QAction, QApplication, QFrame, QH
 from ...puddlesettings import add_config_widget
 from ...puddletag import add_shortcuts, status
 from ...constants import SAVEDIR
-from ...puddleobjects import (natsort_case_key, ListButtons,
+from ...puddleobjects import (natural_sort_key, ListButtons,
                               ListBox, PuddleConfig)
 from ...tagmodel import TableHeader
 from ...translations import translate
@@ -45,7 +45,7 @@ def show_all_fields(fields=None):
         if f in keys:
             keys.remove(f)
 
-    data = [(k, k) for k in fields + sorted(keys, key=natsort_case_key)]
+    data = [(k, k) for k in fields + sorted(keys, key=natural_sort_key)]
     tb = status['table']
     tb.model().setHeader(data)
     hd = TableHeader(Qt.Orientation.Horizontal)

--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -631,9 +631,9 @@ def natural_sort_key(s: Union[str, List[str]], case_insensitive=True) -> QCollat
     if isinstance(s, list):
         s = s[0]
 
-    collator = QCollator(QLocale.system().collation())
-    collator.setCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive if case_insensitive
-                                else Qt.CaseSensitivity.CaseSensitive)
+    locale = QLocale.system().collation() if case_insensitive else QLocale.c()
+    collator = QCollator(locale)
+    collator.setCaseSensitivity(Qt.CaseSensitivity.CaseSensitive)
     collator.setNumericMode(True)
     return collator.sortKey(s)
 

--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -16,6 +16,7 @@ from functools import partial
 from glob import glob
 from io import StringIO
 from itertools import groupby  # for unique function.
+from typing import List, Union
 
 from PyQt5.QtCore import QBuffer, QByteArray, QDir, QRectF, QSettings, QSize, QThread, QTimer, Qt, pyqtSignal
 from PyQt5.QtCore import QFile, QIODevice
@@ -619,24 +620,25 @@ def unique(seq, stable=False):
     return result
 
 
-class compare:
-    "Natural sorting class."
-
-    def natsort_case_key(self, s):
-        "Used internally to get a tuple by which s is sorted."
-        convert = lambda text: int(text) if text.isdigit() else text.lower()
-        return [convert(c) for c in re.split('([0-9]+)', s)]
-
-
-natsort_case_key = compare().natsort_case_key
-
-
 # https://stackoverflow.com/a/16090640
-def natural_sort_key(s, _nsre=re.compile('([0-9]+)')):
+def natural_sort_key(s: Union[str, List[str]], case_insensitive=True, _nsre=re.compile('([0-9]+)')) \
+        -> List[Union[str, int]]:
+    """Return a sort-key for natural sorting the given string.
+
+    Case-insensitive means uppercase- and lowercase-characters are treated equally.
+    Natural means sorting numbers by their numeric value, e.g. 100 comes after 99.
+    """
     if isinstance(s, list):
         s = s[0]
-    return [int(text) if text.isdigit() else text.lower()
-            for text in re.split(_nsre, s)]
+
+    def convert(v: str) -> Union[str, int]:
+        if v.isdigit():
+            return int(v)
+        if case_insensitive:
+            return v.lower()
+        return v
+
+    return [convert(part) for part in re.split(_nsre, s)]
 
 
 def dupes(l, method=None):


### PR DESCRIPTION
## Unify natural sorting functions
There are two nearly identical implementations, a leftover artefact from the py3 migration. Reduced them to one, and fixed/simplified some calling code along the way.

## Make sorting locale aware
The case-sensitivity behaves a bit weird, because it only changes the sorting of strings that only differ in case.

Case-sensitive will always put the lowercase variant first. `AC, ab, aa, AA, ac` becomes `aa, AA, ab, ac, AC`, `aa` and `ac` come before `AA` and `AC` respectively, but in general uppercase and lowercase is still mixed.

Case-insensitive works more or less the same, but instead of putting the lowercase-variant always first it preserves the original order. The same `AC, ab, aa, AA, ac` becomes `aa, AA, ab, AC, ac`, `aa` and `AC` come before `AA` and `ac` respectively because they were originally in that order.

On the other hand, the only place where you can switch between the two is the "sort fields" function.

Fixes #728

## Improve case-sensitive sort
Instead of using the QCollator case-sensitivity flag, switch to the good old C locale. This way we get the expected all-uppercase-first sorting. The downside is, numeric mode does not work, and special characters are no longer properly sorted, e.g. A < a < Á < á. So it's "pick your poison".