### PR TITLE
Replace permadelete with send2trash

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ puddletag uses several third-party modules to performs its tasks:
 - [Mutagen](https://pypi.org/project/mutagen/), used as the tagging lib
 - [Chromaprint](http://acoustid.org/chromaprint) (recommended), for AcoustID support
 - [unidecode](https://pypi.org/project/Unidecode/)
-
+- [send2trash](https://pypi.org/project/Send2Trash/)
 
 ## How to install
 

--- a/puddlestuff/about.py
+++ b/puddlestuff/about.py
@@ -66,6 +66,7 @@ def versions():
         'audioread': get_module_version('audioread'),
         'Levenshtein': get_module_version('Levenshtein'),
         'Chromaprint': get_module_version('chromaprint'),
+        'Send2Trash': get_module_version('send2trash'),
     }
 
 

--- a/puddlestuff/masstag/dialogs.py
+++ b/puddlestuff/masstag/dialogs.py
@@ -2,6 +2,7 @@ import glob
 import os
 from copy import deepcopy
 from functools import partial
+from send2trash import send2trash
 
 from PyQt5.QtCore import QMutex, QObject, pyqtSignal
 from PyQt5.QtWidgets import QApplication, QCheckBox, QComboBox, QDialog, QGridLayout, QHBoxLayout, QLabel, \
@@ -173,7 +174,7 @@ class MassTagEdit(QDialog):
         for f in files:
             if f not in filenames:
                 try:
-                    os.remove(f)
+                    send2trash(f)
                 except EnvironmentError:
                     pass
         for filename, profile in filenames.items():

--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -7,6 +7,7 @@ from copy import copy, deepcopy
 from operator import itemgetter
 from os import path
 from subprocess import Popen
+from send2trash import send2trash
 
 from PyQt5.QtCore import QAbstractTableModel, QEvent, QItemSelection, QItemSelectionModel, QItemSelectionRange, \
     QMimeData, QModelIndex, QPoint, QUrl, Qt, pyqtSignal
@@ -1658,7 +1659,7 @@ class TagTable(QTableView):
             for ((i, row), audio) in zip(enumerate(selectedRows), selected):
                 try:
                     filename = audio.filepath
-                    os.remove(filename)
+                    send2trash(filename)
                     if audio.library:
                         audio.remove()
                         libtags.append(audio)

--- a/requirements.in
+++ b/requirements.in
@@ -4,6 +4,7 @@ configobj==5.0.8
 mutagen==1.46.0
 pyparsing==3.0.9
 unidecode==1.3.6
+Send2Trash
 
 # extra / tag sources
 lxml==4.9.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,8 @@ rapidfuzz==2.13.7
     # via levenshtein
 requests==2.31.0
     # via pyacoustid
+send2trash==1.8.2
+    # via -r requirements.in
 six==1.16.0
     # via configobj
 unidecode==1.3.6


### PR DESCRIPTION
This PR addresses #223 by replacing all instances of `os.remove()` (within puddletag itself, not `docsrc`) with `send2trash()`.

I don't think an option to enable permadeleting is necessary because if a user wants to permadelete a file, they can do so within their file manager, and they won't run into any unexpected results there.

This should affect all delete operations, including `[Shift][Del]` which currently doesn't prompt the user for confirmation to delete selected files.

An undo option seems to be much trickier and platform-dependent to implement, though it isn't really necessary.