### PR TITLE
Fix masstag coredump

### DIFF
--- a/puddlestuff/masstag/__init__.py
+++ b/puddlestuff/masstag/__init__.py
@@ -571,8 +571,8 @@ class MassTagProfile(object):
         profiles = self.profiles if profiles is None else profiles
         regexps = self.regexps if regexps is None else regexps
 
-        assert files
-        assert profiles
+        if not files or not profiles:
+            return
 
         self.files = files
 

--- a/puddlestuff/masstag/dialogs.py
+++ b/puddlestuff/masstag/dialogs.py
@@ -369,10 +369,10 @@ class MTProfileEdit(QDialog):
     def setProfile(self, profile):
         self._tsps = [tsp for tsp in profile.profiles if tsp.tag_source]
         [self.listbox.addItem(tsp.tag_source.name) for tsp in self._tsps]
-        self.albumBound.setValue(profile.album_bound * 100)
+        self.albumBound.setValue(int(profile.album_bound * 100))
         self.pattern.setText(profile.file_pattern)
         self.matchFields.setText(', '.join(profile.fields))
-        self.trackBound.setValue(profile.track_bound * 100)
+        self.trackBound.setValue(int(profile.track_bound * 100))
         self.jfdi.setChecked(profile.jfdi)
         self._name.setText(profile.name)
         self._desc.setText(profile.desc)


### PR DESCRIPTION
## Fix percentage input in masstag editor
The two percentages are stored internally as float in the range 0 to 1, but the QSpinBox used in the UI can only do int, so the value is multiplied by 100 to bring it into the range of 0 to 100. But float times int is still float, it requires an explicit cast.

## Remove assertion in masstag
When there are no files or no profiles, simply shortcircuit instead of a hard-exit with an assertion failure.

Fixes #720