### PR TITLE
Some code cleanup

### DIFF
--- a/console
+++ b/console
@@ -27,9 +27,9 @@ from puddlestuff.findfunc import *
 
 noprints = ['__path', '__ext', '__modified', '__accessed', '__folder']
 sortorder = ['__filename', '__size', '__length', '__bitrate', '__frequency', '__created']
-bold = chr(0x1b) + "[1m";
-normal = chr(0x1b) + "[0m";
-red = chr(0x1b) + "[31m";
+bold = chr(0x1b) + "[1m"
+normal = chr(0x1b) + "[0m"
+red = chr(0x1b) + "[31m"
 
 
 def printerror(text):

--- a/puddlestuff/action_shortcuts.py
+++ b/puddlestuff/action_shortcuts.py
@@ -134,7 +134,7 @@ class Shortcut(QAction):
 
 
 class Editor(QDialog):
-    actionChanged = pyqtSignal(str, list, str, name='actionChanged');
+    actionChanged = pyqtSignal(str, list, str, name='actionChanged')
 
     def __init__(self, title='Add Action', shortcut='', actions=None, names=None, shortcuts=None, parent=None):
         super(Editor, self).__init__(parent)

--- a/puddlestuff/audio_filter.py
+++ b/puddlestuff/audio_filter.py
@@ -33,7 +33,6 @@ def parse_arg(audio, text):
         if text[0] == '"' and text[-1] == '"':
             text = text[1:-1]
         return findfunc.parsefunc(text, audio)
-    return ""
 
 
 def wrap_bool(original):

--- a/puddlestuff/audioinfo/apev2.py
+++ b/puddlestuff/audioinfo/apev2.py
@@ -61,25 +61,25 @@ def get_class(mutagen_file, filetype, attrib_fields, header_error=None):
 
             MockTag.__init__(self, filename)
 
-        def get_filepath(self):
+        @property
+        def filepath(self):
             return MockTag.get_filepath(self)
 
-        def set_filepath(self, val):
+        @filepath.setter
+        def filepath(self, val):
             self.__tags.update(MockTag.set_filepath(self, val))
 
-        filepath = property(get_filepath, set_filepath)
-
-        def _get_images(self):
+        @property
+        def images(self):
             return self.__images
 
-        def _set_images(self, images):
+        @images.setter
+        def images(self, images):
             if images:
                 self.__images = [parse_image(i, self.IMAGETAGS) for i in images]
             else:
                 self.__images = []
             cover_info(images, self.__tags)
-
-        images = property(_get_images, _set_images)
 
         def __contains__(self, key):
             if key == '__image':
@@ -150,7 +150,8 @@ def get_class(mutagen_file, filetype, attrib_fields, header_error=None):
                 del (self.__tags[self.revmapping.get(key, key)])
             self.images = []
 
-        def _info(self):
+        @property
+        def info(self):
             info = self.mut_obj.info
             fileinfo = [('Path', self[PATH]),
                         ('Size', str_filesize(int(self.size))),
@@ -166,8 +167,6 @@ def get_class(mutagen_file, filetype, attrib_fields, header_error=None):
                 except AttributeError:
                     continue
             return [('File', fileinfo), ("%s Info" % self.filetype, apeinfo)]
-
-        info = property(_info)
 
         @keys_deco
         def keys(self):
@@ -262,7 +261,8 @@ mp_base = get_class(Musepack, 'Musepack',
 
 
 class MusePackTag(mp_base):
-    def _info(self):
+    @property
+    def info(self):
         info = self.mut_obj.info
         fileinfo = [('Path', self[PATH]),
                     ('Size', str_filesize(int(self.size))),
@@ -275,8 +275,6 @@ class MusePackTag(mp_base):
                   ('Stream Version', str(info.version))]
         return [('File', fileinfo), ("Musepack Info", mpinfo)]
 
-    info = property(_info)
-
 
 ma_base = get_class(MonkeysAudio, "Monkey's Audio",
                     ATTRIBUTES + ['bitrate', 'frequency', 'version', 'channels'],
@@ -284,7 +282,8 @@ ma_base = get_class(MonkeysAudio, "Monkey's Audio",
 
 
 class MonkeysAudioTag(ma_base):
-    def _info(self):
+    @property
+    def info(self):
         info = self.mut_obj.info
         fileinfo = [('Path', self[PATH]),
                     ('Size', str_filesize(int(self.size))),
@@ -297,15 +296,14 @@ class MonkeysAudioTag(ma_base):
                   ('Stream Version', str(info.version))]
         return [('File', fileinfo), ("Monkey's Audio", mainfo)]
 
-    info = property(_info)
-
 
 wv_base = get_class(WavPack, 'WavPack',
                     ATTRIBUTES + ['frequency', 'bitrate'], WavPackHeaderError)
 
 
 class WavPackTag(wv_base):
-    def _info(self):
+    @property
+    def info(self):
         info = self.mut_obj.info
         fileinfo = [('Path', self[PATH]),
                     ('Size', str_filesize(int(self.size))),
@@ -316,8 +314,6 @@ class WavPackTag(wv_base):
                   ('Length', self.length),
                   ('Bitrate', 'Lossless')]
         return [('File', fileinfo), ("WavPack Info", wpinfo)]
-
-    info = property(_info)
 
 
 Tag = get_class(APEv2File, 'APEv2', ATTRIBUTES)

--- a/puddlestuff/audioinfo/id3.py
+++ b/puddlestuff/audioinfo/id3.py
@@ -853,7 +853,7 @@ def tag_factory(id3_filetype):
                 mpginfo = [('Type', 'DSF')]
             elif isinstance(self.mut_obj, AIFFFileType):
                 mpginfo = [('Type', 'AIFF')]
-            elif (self.mut_obj, ID3FileType):
+            elif isinstance(self.mut_obj, ID3FileType):
                 mpginfo = [('Version', 'MPEG %i Layer %i' % (info.version, info.layer))]
             else:
                 mpginfo = []

--- a/puddlestuff/audioinfo/id3.py
+++ b/puddlestuff/audioinfo/id3.py
@@ -816,27 +816,28 @@ def tag_factory(id3_filetype):
 
             util.MockTag.__init__(self, filename)
 
-        def get_filepath(self):
+        @property
+        def filepath(self):
             return util.MockTag.get_filepath(self)
 
-        def set_filepath(self, val):
+        @filepath.setter
+        def filepath(self, val):
             self.__tags.update(util.MockTag.set_filepath(self, val))
 
-        filepath = property(get_filepath, set_filepath)
-
-        def _get_images(self):
+        @property
+        def images(self):
             return self.__images
 
-        def _set_images(self, images):
+        @images.setter
+        def images(self, images):
             if images:
                 self.__images = [parse_image(i, self.IMAGETAGS) for i in images]
             else:
                 self.__images = []
             cover_info(images, self.__tags)
 
-        images = property(_get_images, _set_images)
-
-        def _info(self):
+        @property
+        def info(self):
             info = self.mut_obj.info
             fileinfo = [('Path', self[PATH]),
                         ('Size', str_filesize(int(self.size))),
@@ -879,8 +880,6 @@ def tag_factory(id3_filetype):
                 pass
 
             return [('File', fileinfo), (mpginfo[0][0], mpginfo)]
-
-        info = property(_info)
 
         def __contains__(self, key):
             if key == '__image':

--- a/puddlestuff/audioinfo/id3.py
+++ b/puddlestuff/audioinfo/id3.py
@@ -1022,7 +1022,7 @@ def tag_factory(id3_filetype):
                 if apics:
                     self.images = list(map(bin_to_pic, apics))
                 else:
-                    self.images = [];
+                    self.images = []
 
             self.__tags.update(tags)
             self.__tags.update(info_to_dict(audio.info))

--- a/puddlestuff/audioinfo/mp4.py
+++ b/puddlestuff/audioinfo/mp4.py
@@ -194,13 +194,13 @@ class Tag(util.MockTag):
 
         util.MockTag.__init__(self, filename)
 
-    def get_filepath(self):
+    @property
+    def filepath(self):
         return util.MockTag.get_filepath(self)
 
-    def set_filepath(self, val):
+    @filepath.setter
+    def filepath(self, val):
         self.__tags.update(util.MockTag.set_filepath(self, val))
-
-    filepath = property(get_filepath, set_filepath)
 
     def __contains__(self, key):
         if key == '__image':
@@ -284,19 +284,20 @@ class Tag(util.MockTag):
             del (self.__tags[self.revmapping.get(key, key)])
         self.images = []
 
-    def _set_images(self, images):
+    @property
+    def images(self):
+        return self.__images
+
+    @images.setter
+    def images(self, images):
         if images:
             self.__images = [parse_image(i, self.IMAGETAGS) for i in images]
         else:
             self.__images = []
         cover_info(images, self.__tags)
 
-    def _get_images(self):
-        return self.__images
-
-    images = property(_get_images, _set_images)
-
-    def _info(self):
+    @property
+    def info(self):
         info = self.mut_obj.info
         fileinfo = [('Path', self[PATH]),
                     ('Size', str_filesize(int(self.size))),
@@ -310,8 +311,6 @@ class Tag(util.MockTag):
                    ('Bits per sample', str(info.bits_per_sample))]
 
         return [('File', fileinfo), ('MP4 Info', mp4info)]
-
-    info = property(_info)
 
     def link(self, filename):
         """Links the audio, filename

--- a/puddlestuff/audioinfo/util.py
+++ b/puddlestuff/audioinfo/util.py
@@ -756,7 +756,14 @@ class MockTag(object):
 
         return ret
 
-    def _set_ext(self, val):
+    filepath = property(get_filepath, set_filepath)
+
+    @property
+    def ext(self):
+        return path.splitext(self.filepath)[1][1:]
+
+    @ext.setter
+    def ext(self, val):
         if val:
             val = path_to_string(val)
             self.filepath = '%s%s%s' % (path.splitext(self.filepath)[0],
@@ -764,51 +771,56 @@ class MockTag(object):
         else:
             self.filepath = path.splitext(self.filepath)[0]
 
-    def _get_ext(self):
-        return path.splitext(self.filepath)[1][1:]
-
-    def _get_filename(self):
+    @property
+    def filename(self):
         return path.basename(self.filepath)
 
-    def _set_filename(self, val):
+    @filename.setter
+    def filename(self, val):
         val = path_to_string(val)
         self.filepath = path.join(self.dirpath, val)
 
-    def _get_dirpath(self):
+    @property
+    def dirpath(self):
         return path.dirname(self.filepath)
 
-    def _set_dirpath(self, val):
+    @dirpath.setter
+    def dirpath(self, val):
         val = path_to_string(val)
         self.filepath = path.join(val, self.filename)
 
-    def _get_dirname(self):
+    @property
+    def dirname(self):
         return path.basename(self.dirpath)
 
-    def _set_dirname(self, value):
+    @dirname.setter
+    def dirname(self, value):
         value = path_to_string(value)
         self.dirpath = path.join(path.dirname(self.dirpath), value)
 
-    def _set_filename_no_ext(self, value):
-        self.filename = value + '.' + self.ext
-
-    def _get_filename_no_ext(self):
+    @property
+    def filename_no_ext(self):
         return path.splitext(path.basename(self.filepath))[0]
 
-    def _get_parent_dir(self):
+    @filename_no_ext.setter
+    def filename_no_ext(self, value):
+        self.filename = value + '.' + self.ext
+
+    @property
+    def parent_dir(self):
         return path.basename(path.dirname(self.dirpath))
 
-    def _set_parent_dir(self, value):
+    @parent_dir.setter
+    def parent_dir(self, value):
         self.dirpath = path.join(path.dirname(self.dirpath), value)
 
-    filepath = property(get_filepath, set_filepath)
-    dirpath = property(_get_dirpath, _set_dirpath)
-    dirname = property(_get_dirname, _set_dirname)
-    ext = property(_get_ext, _set_ext)
-    filename = property(_get_filename, _set_filename)
-    filename_no_ext = property(_get_filename_no_ext, _set_filename_no_ext)
-    parent_dir = property(_get_parent_dir, _set_parent_dir)
-    tags = property(lambda self: dict(list(self.items())))
-    usertags = property(lambda self: usertags(self))
+    @property
+    def tags(self):
+        return dict(list(self.items()))
+
+    @property
+    def usertags(self):
+        return usertags(self)
 
     def __iter__(self):
         return list(self.keys()).__iter__()

--- a/puddlestuff/audioinfo/vorbis.py
+++ b/puddlestuff/audioinfo/vorbis.py
@@ -75,25 +75,25 @@ def vorbis_tag(base, name):
 
             util.MockTag.__init__(self, filename)
 
-        def get_filepath(self):
+        @property
+        def filepath(self):
             return util.MockTag.get_filepath(self)
 
-        def set_filepath(self, val):
+        @filepath.setter
+        def filepath(self, val):
             self.__tags.update(util.MockTag.set_filepath(self, val))
 
-        filepath = property(get_filepath, set_filepath)
-
-        def _get_images(self):
+        @property
+        def images(self):
             return self.__images
 
-        def _set_images(self, images):
+        @images.setter
+        def images(self, images):
             if images:
                 self.__images = [parse_image(i, self.IMAGETAGS) for i in images]
             else:
                 self.__images = []
             cover_info(images, self.__tags)
-
-        images = property(_get_images, _set_images)
 
         def __contains__(self, key):
             if key == '__image':
@@ -246,8 +246,8 @@ def vorbis_tag(base, name):
 
 
 class Ogg_Tag(vorbis_tag(OggVorbis, 'Ogg Vorbis')):
-
-    def _info(self):
+    @property
+    def info(self):
         info = self.mut_obj.info
         fileinfo = [
             ('Path', self[PATH]),
@@ -261,12 +261,11 @@ class Ogg_Tag(vorbis_tag(OggVorbis, 'Ogg Vorbis')):
                    ('Length', self.length)]
         return [('File', fileinfo), ('Ogg Info', ogginfo)]
 
-    info = property(_info)
-
 
 if OggOpus:
     class Opus_Tag(vorbis_tag(OggOpus, 'Ogg Opus')):
-        def _info(self):
+        @property
+        def info(self):
             info = self.mut_obj.info
             fileinfo = [
                 ('Path', self[PATH]),
@@ -279,11 +278,10 @@ if OggOpus:
                        ('Length', self.length)]
             return [('File', fileinfo), ('Opus Info', ogginfo)]
 
-        info = property(_info)
-
 
 class FLAC_Tag(vorbis_tag(FLAC, 'FLAC')):
-    def _info(self):
+    @property
+    def info(self):
         info = self.mut_obj.info
         fileinfo = [('Path', self[PATH]),
                     ('Size', str_filesize(int(self.size))),
@@ -296,8 +294,6 @@ class FLAC_Tag(vorbis_tag(FLAC, 'FLAC')):
                    ('Channels', str(info.channels)),
                    ('Length', self.length)]
         return [('File', fileinfo), ('FLAC Info', ogginfo)]
-
-    info = property(_info)
 
 
 filetypes = []

--- a/puddlestuff/audioinfo/wma.py
+++ b/puddlestuff/audioinfo/wma.py
@@ -120,25 +120,25 @@ class Tag(util.MockTag):
 
         util.MockTag.__init__(self, filename)
 
-    def get_filepath(self):
+    @property
+    def filepath(self):
         return util.MockTag.get_filepath(self)
 
-    def set_filepath(self, val):
+    @filepath.setter
+    def filepath(self, val):
         self.__tags.update(util.MockTag.set_filepath(self, val))
 
-    filepath = property(get_filepath, set_filepath)
-
-    def _getImages(self):
+    @property
+    def images(self):
         return self.__images
 
-    def _setImages(self, images):
+    @images.setter
+    def images(self, images):
         if images:
             self.__images = list(map(parse_image, images))
         else:
             self.__images = []
         cover_info(images, self.__tags)
-
-    images = property(_getImages, _setImages)
 
     def __contains__(self, key):
         if key == '__image':
@@ -195,7 +195,8 @@ class Tag(util.MockTag):
         self.images = []
         self.save()
 
-    def _info(self):
+    @property
+    def info(self):
         info = self.mut_obj.info
         fileinfo = [('Path', self[PATH]),
                     ('Size', str_filesize(int(self.size))),
@@ -207,8 +208,6 @@ class Tag(util.MockTag):
                    ('Channels', str(info.channels)),
                    ('Length', self.length)]
         return [('File', fileinfo), ('ASF Info', wmainfo)]
-
-    info = property(_info)
 
     @keys_deco
     def keys(self):

--- a/puddlestuff/duplicates/algwin.py
+++ b/puddlestuff/duplicates/algwin.py
@@ -368,7 +368,12 @@ class SetDialog(QDialog):
         self.setscombo.setCurrentIndex(0)
         self.setscombo.currentIndexChanged.connect(self.changeSet)
 
-    def _setCurrentSet(self, s):
+    @property
+    def currentSet(self):
+        return self._sets[self.setscombo.currentIndex()]
+
+    @currentSet.setter
+    def currentSet(self, s):
         [text.setText(disp) for text, disp in zip(self.texts, s[1])]
         self.listbox.clear()
         [self.listbox.addItem(alg.pprint()) for alg in s[2]]
@@ -378,11 +383,6 @@ class SetDialog(QDialog):
         else:
             self.maintag.addItem(s[3])
             self.maintag.setCurrentIndex(self.maintag.count() - 1)
-
-    def _getCurrentSet(self):
-        return self._sets[self.setscombo.currentIndex()]
-
-    currentSet = property(_getCurrentSet, _setCurrentSet)
 
     def changeSet(self, index):
         i = self._previndex

--- a/puddlestuff/duplicates/matchfuncs.py
+++ b/puddlestuff/duplicates/matchfuncs.py
@@ -65,7 +65,12 @@ class Algo(object):
         self.func = func
         self.matchcase = matchcase
 
-    def _setFunc(self, func):
+    @property
+    def func(self):
+        return self._func
+
+    @func.setter
+    def func(self, func):
         if isinstance(func, str):
             funcnames = [f.__name__ for f in funcs]
             try:
@@ -74,11 +79,6 @@ class Algo(object):
                 return
         self._func = func
         self.funcname, self.funcdesc = funcinfo(func)
-
-    def _getFunc(self):
-        return self._func
-
-    func = property(_getFunc, _setFunc)
 
     def pprint(self):
         threshold = '%.2f' % (self.threshold * 100) + '%'

--- a/puddlestuff/functions.py
+++ b/puddlestuff/functions.py
@@ -744,14 +744,7 @@ Match &Case, check"""
 
     def replace_matches(value):
         try:
-            try:
-                return re.sub(regex, replace_tokens, value, 0, flags)
-            except TypeError:
-                # Python2.6 doesn't accept flags arg.
-                if matchcase:
-                    return re.sub('(?i)' + regex, replace_tokens, value, 0)
-                else:
-                    return re.sub(regex, replace_tokens, value, 0)
+            return re.sub(regex, replace_tokens, value, 0, flags)
         except re.error as e:
             raise findfunc.FuncError(str(e))
 

--- a/puddlestuff/helperwin.py
+++ b/puddlestuff/helperwin.py
@@ -455,20 +455,22 @@ class StatusWidgetItem(QTableWidgetItem):
         self._original = (text, preview, status)
         self.linked = []
 
-    def _get_preview(self):
+    @property
+    def preview(self):
         return self.font().bold()
 
-    def _set_preview(self, value):
+    @preview.setter
+    def preview(self, value):
         font = self.font()
         font.setBold(value)
         self.setFont(font)
 
-    preview = property(_get_preview, _set_preview)
-
-    def _get_status(self):
+    @property
+    def status(self):
         return self._status
 
-    def _set_status(self, status):
+    @status.setter
+    def status(self, status):
         if status and status in self.statusColors:
             if self._status == ADD and status != REMOVE:
                 return
@@ -477,8 +479,6 @@ class StatusWidgetItem(QTableWidgetItem):
         else:
             self.setBackground(QTableWidgetItem().background())
             self._status = None
-
-    status = property(_get_status, _set_status)
 
     def __lt__(self, item):
         if self.text().upper() < item.text().upper():
@@ -534,18 +534,20 @@ class StatusWidgetCombo(QComboBox):
         self._original = (items, preview, status)
         self.linked = []
 
-    def _get_preview(self):
+    @property
+    def preview(self):
         return False
 
-    def _set_preview(self, value):
+    @preview.setter
+    def preview(self, _):
         return
 
-    preview = property(_get_preview, _set_preview)
-
-    def _get_status(self):
+    @property
+    def status(self):
         return self._status
 
-    def _set_status(self, status):
+    @status.setter
+    def status(self, status):
         if status and status in self.statusColors:
             if self._status == ADD and status != REMOVE:
                 return
@@ -554,8 +556,6 @@ class StatusWidgetCombo(QComboBox):
         else:
             self.setBackground(None)
             self._status = None
-
-    status = property(_get_status, _set_status)
 
     def setBackground(self, brush=None):
         if brush is None:

--- a/puddlestuff/helperwin.py
+++ b/puddlestuff/helperwin.py
@@ -566,7 +566,7 @@ class StatusWidgetCombo(QComboBox):
             color = QLineEdit().palette().color(QPalette.ColorRole.Base).name()
         else:
             color = brush.color().name()
-        self.setStyleSheet("QComboBox { background-color: %s; }" % color);
+        self.setStyleSheet("QComboBox { background-color: %s; }" % color)
 
     def background(self):
         brush = QBrush()

--- a/puddlestuff/helperwin.py
+++ b/puddlestuff/helperwin.py
@@ -536,13 +536,9 @@ class StatusWidgetCombo(QComboBox):
 
     def _get_preview(self):
         return False
-        return self.font().bold()
 
     def _set_preview(self, value):
         return
-        font = self.font()
-        font.setBold(value)
-        self.setFont(font)
 
     preview = property(_get_preview, _set_preview)
 

--- a/puddlestuff/libraries/quodlibetlib.py
+++ b/puddlestuff/libraries/quodlibetlib.py
@@ -108,15 +108,15 @@ class Tag(MockTag):
         self.set_attrs(ATTRIBUTES, self.__tags)
         self.update_tag_list()
 
-    def get_filepath(self):
+    @property
+    def filepath(self):
         return MockTag.get_filepath(self)
 
-    def set_filepath(self, val):
+    @filepath.setter
+    def filepath(self, val):
         self.__tags.update(MockTag.set_filepath(self, val))
 
-    filepath = property(get_filepath, set_filepath)
-
-    images = property(lambda s: [], lambda s: [])
+    images = property(lambda self: [], lambda self, value: None)
 
     def __contains__(self, key):
         if self.revmapping:
@@ -259,10 +259,9 @@ class QuodLibet(object):
         return set([track.get(child, '') for track in
                     self._tracks if track.get(parent, '') == value])
 
-    def _artists(self):
+    @property
+    def artists(self):
         return list(self._cached.keys())
-
-    artists = property(_artists)
 
     def get_albums(self, artist):
         return list(self._cached[artist].keys())

--- a/puddlestuff/mainwin/artwork.py
+++ b/puddlestuff/mainwin/artwork.py
@@ -36,7 +36,7 @@ def create_svg(text, font, rect=None):
     generator = QSvgGenerator()
     generator.setFileName(f.name)
     generator.setSize(rect.size())
-    generator.setViewBox(rect);
+    generator.setViewBox(rect)
     generator.setTitle("puddletag image")
     generator.setDescription("just to see")
 

--- a/puddlestuff/mainwin/releasewidget.py
+++ b/puddlestuff/mainwin/releasewidget.py
@@ -164,14 +164,14 @@ class TreeItem(RootItem):
     def data(self, column):
         return self._display
 
-    def _getDisp(self):
+    @property
+    def dispPattern(self):
         return self._pattern
 
-    def _setDisp(self, pattern):
+    @dispPattern.setter
+    def dispPattern(self, pattern):
         self._pattern = pattern
         self._display = inline_display(pattern, self.itemData)
-
-    dispPattern = property(_getDisp, _setDisp)
 
     def exact_matches(self):
         ret = []
@@ -224,14 +224,14 @@ class ChildItem(RootItem):
     def data(self, column):
         return self._display
 
-    def _getDisp(self):
+    @property
+    def dispPattern(self):
         return self._pattern
 
-    def _setDisp(self, pattern):
+    @dispPattern.setter
+    def dispPattern(self, pattern):
         self._pattern = pattern
         self._display = inline_display(pattern, self.itemData)
-
-    dispPattern = property(_getDisp, _setDisp)
 
     def track(self):
         track = self.parentItem.itemData.copy()
@@ -281,10 +281,12 @@ class TreeModel(QtCore.QAbstractItemModel):
         if data:
             self.setupModelData(data)
 
-    def _get_albumPattern(self):
+    @property
+    def albumPattern(self):
         return self._albumPattern
 
-    def _set_albumPattern(self, value):
+    @albumPattern.setter
+    def albumPattern(self, value):
         self._albumPattern = value
         for item in self.rootItem.childItems:
             item.dispPattern = value
@@ -293,21 +295,21 @@ class TreeModel(QtCore.QAbstractItemModel):
         bottom = self.index(self.rowCount(parent) - 1, 0, parent)
         self.dataChanged.emit(top, bottom)
 
-    albumPattern = property(_get_albumPattern, _set_albumPattern)
-
-    def _get_sortOrder(self):
+    @property
+    def sortOrder(self):
         return self._sortOrder
 
-    def _set_sortOrder(self, value):
+    @sortOrder.setter
+    def sortOrder(self, value):
         self._sortOrder = value
         self.sort()
 
-    sortOrder = property(_get_sortOrder, _set_sortOrder)
-
-    def _get_trackPattern(self):
+    @property
+    def trackPattern(self):
         return self._trackPattern
 
-    def _set_trackPattern(self, value):
+    @trackPattern.setter
+    def trackPattern(self, value):
         self._trackPattern = value
         for row, parent_item in enumerate(self.rootItem.childItems):
             if parent_item.childItems and parent_item.hasTracks:
@@ -318,8 +320,6 @@ class TreeModel(QtCore.QAbstractItemModel):
                 bottom = self.index(self.rowCount(parent_index)
                                     -1, 0, parent_index)
                 self.dataChanged.emit(top, bottom)
-
-    trackPattern = property(_get_trackPattern, _set_trackPattern)
 
     def canFetchMore(self, index):
         item = index.internalPointer()
@@ -566,32 +566,32 @@ class ReleaseWidget(QTreeView):
         model = TreeModel()
         self.setModel(model)
 
-    def _get_albumPattern(self):
+    @property
+    def albumPattern(self):
         return self._albumPattern
 
-    def _set_albumPattern(self, value):
+    @albumPattern.setter
+    def albumPattern(self, value):
         self._albumPattern = value
         self.model().albumPattern = value
 
-    albumPattern = property(_get_albumPattern, _set_albumPattern)
-
-    def _get_trackPattern(self):
+    @property
+    def trackPattern(self):
         return self._trackPattern
 
-    def _set_trackPattern(self, value):
+    @trackPattern.setter
+    def trackPattern(self, value):
         self._trackPattern = value
         self.model().trackPattern = value
 
-    trackPattern = property(_get_trackPattern, _set_trackPattern)
-
-    def _get_tagSource(self):
+    @property
+    def tagSource(self):
         return self._tagSource
 
-    def _set_tagSource(self, source):
+    @tagSource.setter
+    def tagSource(self, source):
         self._tagSource = source
         self.model().tagsource = source
-
-    tagSource = property(_get_tagSource, _set_tagSource)
 
     def cleanTrack(self, track):
         return strip(track, self.tagsToWrite, mapping=self.mapping)

--- a/puddlestuff/mainwin/tagpanel.py
+++ b/puddlestuff/mainwin/tagpanel.py
@@ -408,7 +408,9 @@ class PuddleTable(QTableWidget):
         curitem = self.item(row + 1, self.currentItem().column())
         self.setCurrentItem(curitem)
 
-    rows = property(lambda x: range(x.rowCount()))
+    @property
+    def rows(self):
+        return range(self.rowCount())
 
     def setRowTexts(self, row, texts):
         item = self.item

--- a/puddlestuff/masstag/__init__.py
+++ b/puddlestuff/masstag/__init__.py
@@ -628,27 +628,29 @@ class Result(object):
         self.info = {} if info is None else info
         self.track_matched = {}
 
-    def _get_info(self):
-        return self.__info
-
-    def _set_info(self, value):
-        self.__info = value
-
+    def _update_merged(self):
         if self.__tracks:
-            self.merged = [merge_track(a, value) for a in self.__tracks]
+            self.merged = [merge_track(a, self.__info) for a in self.__tracks]
         else:
             self.merged = []
 
-    info = property(_get_info, _set_info)
+    @property
+    def info(self):
+        return self.__info
 
-    def _get_tracks(self):
+    @info.setter
+    def info(self, value):
+        self.__info = value
+        self._update_merged()
+
+    @property
+    def tracks(self):
         return self.__tracks
 
-    def _set_tracks(self, value):
+    @tracks.setter
+    def tracks(self, value):
         self.__tracks = value
-        self._set_info(self.__info)
-
-    tracks = property(_get_tracks, _set_tracks)
+        self._update_merged()
 
     def retrieve(self, errors=None):
         if self.tag_source:

--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -74,38 +74,9 @@ def keycmp(modifier):
         return 0
 
 
-try:
-    permutations = itertools.permutations
-except AttributeError:
-    # Using python < 2.6
-    def permutations(iterable, r=None):
-        # permutations('ABCD', 2) --> AB AC AD BA BC BD CA CB CD DA DB DC
-        # permutations(range(3)) --> 012 021 102 120 201 210
-        pool = tuple(iterable)
-        n = len(pool)
-        r = n if r is None else r
-        if r > n:
-            return
-        indices = list(range(n))
-        cycles = list(range(n, n - r, -1))
-        yield tuple(pool[i] for i in indices[:r])
-        while n:
-            for i in reversed(list(range(r))):
-                cycles[i] -= 1
-                if cycles[i] == 0:
-                    indices[i:] = indices[i + 1:] + indices[i:i + 1]
-                    cycles[i] = n - i
-                else:
-                    j = cycles[i]
-                    indices[i], indices[-j] = indices[-j], indices[i]
-                    yield tuple(pool[i] for i in indices[:r])
-                    break
-            else:
-                return
-
 modifiers = {}
 for i in range(1, len(mod_keys)):
-    for keys in set(permutations(mod_keys, i)):
+    for keys in set(itertools.permutations(mod_keys, i)):
         mod = keys[0]
         for key in keys[1:]:
             mod = mod | key

--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -1661,8 +1661,8 @@ class PicWidget(QWidget):
             v.addWidget(self._image_size)
             v.addStretch()
 
-        h = QHBoxLayout();
-        h.addStretch();
+        h = QHBoxLayout()
+        h.addStretch()
         h.addLayout(v)
         if not buttons:
             h.addLayout(movebuttons)

--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -179,7 +179,7 @@ class PuddleConfig(object):
     def __init__(self, filename=None):
         if not filename:
             filename = os.path.join(CONFIGDIR, 'puddletag.conf')
-        self._setFilename(filename)
+        self.filename = filename
 
         self.setSection = self.set
         self.load = self.get
@@ -237,19 +237,20 @@ class PuddleConfig(object):
         with open(filename, 'w') as fo:
             fo.write(json.dumps(dict(self.data), indent=2))
 
-    def _setFilename(self, filename):
+
+    @property
+    def filename(self):
+        return self._filename
+
+    @filename.setter
+    def filename(self, filename):
         logging.debug(f'reading config file {filename}')
         self._filename = filename
         self.savedir = os.path.dirname(filename)
         self.reload()
 
-    def _getFilename(self):
-        return self._filename
-
     def sections(self):
         return list(self.data.keys())
-
-    filename = property(_getFilename, _setFilename)
 
 
 def _getSettings():
@@ -1337,7 +1338,12 @@ class MoveButtons(QWidget):
         self.next.clicked.connect(self.nextClicked)
         self.prev.clicked.connect(self.prevClicked)
 
-    def _setCurrentIndex(self, index):
+    @property
+    def index(self):
+        return self._currentindex
+
+    @index.setter
+    def index(self, index):
         try:
             if index >= len(self.arrayname) or index < 0:
                 return
@@ -1365,11 +1371,6 @@ class MoveButtons(QWidget):
             self.next.show()
 
         self.indexChanged.emit(index)
-
-    def _getCurrentIndex(self):
-        return self._currentindex
-
-    index = property(_getCurrentIndex, _setCurrentIndex)
 
     def nextClicked(self):
         self.index += 1
@@ -1752,18 +1753,18 @@ class PicWidget(QWidget):
 
         self._lastdata = None
 
-    def _setContext(self, text):
+    @property
+    def context(self):
+        return self._contextlabel.text()
+
+    @context.setter
+    def context(self, text):
         if not text:
             self._contextlabel.setVisible(False)
             self._contextlabel.setText('')
         else:
             self._contextlabel.setText(translate("Artwork Context", text))
             self._contextlabel.setVisible(True)
-
-    def _getContext(self):
-        return self._contextlabel.text()
-
-    context = property(_getContext, _setContext)
 
     def setDescription(self, text):
         '''Sets the description of the current image to the text in the
@@ -1876,10 +1877,14 @@ class PicWidget(QWidget):
             self.next.show()
             self.prev.show()
 
-    def _getCurrentImage(self):
+    @property
+    def currentImage(self):
+        """Get or set the index of the current image. If the index isn't valid
+           then a blank image is loaded."""
         return self._currentImage
 
-    def _setCurrentImage(self, num):
+    @currentImage.setter
+    def currentImage(self, num):
         while True:
             # A lot of files have corrupt picture data. I just want to
             # skip those and not have the user be any wiser.
@@ -1946,10 +1951,6 @@ class PicWidget(QWidget):
         self.label.setFrameStyle(QFrame.Shape.NoFrame)
         self.enableButtons()
         # self.resizeEvent()
-
-    currentImage = property(_getCurrentImage, _setCurrentImage, """Get or set the index of
-    the current image. If the index isn't valid
-    then a blank image is loaded.""")
 
     def maxImage(self):
         """Shows a window with the picture fullsized."""
@@ -2225,10 +2226,9 @@ class ProgressWin(QDialog):
             self._timer.stop()
         super(ProgressWin, self).closeEvent(event)
 
-    def _value(self):
+    @property
+    def value(self):
         return self.pbar.value()
-
-    value = property(_value)
 
 
 class PuddleCombo(QWidget):
@@ -2458,14 +2458,14 @@ class ShortcutEditor(QLineEdit):
         self.setText(text)
         self.valid = valid
 
-    def _getValid(self):
+    @property
+    def valid(self):
         return self._valid
 
-    def _setValid(self, value):
+    @valid.setter
+    def valid(self, value):
         self._valid = value
         self.validityChanged.emit(value)
-
-    valid = property(_getValid, _setValid)
 
 
 if __name__ == '__main__':

--- a/puddlestuff/puddlesettings.py
+++ b/puddlestuff/puddlesettings.py
@@ -72,19 +72,19 @@ class SettingsCheckBox(QCheckBox):
         self.settingValue = default
         self._text = text
 
-    def _value(self):
+    @property
+    def settingValue(self):
         if self.checkState() == Qt.CheckState.Checked:
             return self._text, True
         else:
             return self._text, False
 
-    def _setValue(self, value):
+    @settingValue.setter
+    def settingValue(self, value):
         if value:
             self.setCheckState(Qt.CheckState.Checked)
         else:
             self.setCheckState(Qt.CheckState.Unchecked)
-
-    settingValue = property(_value, _setValue)
 
 
 class SettingsLineEdit(QWidget):
@@ -101,13 +101,13 @@ class SettingsLineEdit(QWidget):
         vbox.addWidget(self._text)
         self.setLayout(vbox)
 
-    def _value(self):
+    @property
+    def settingValue(self):
         return self._desc, str(self._text.text())
 
-    def _setValue(self, value):
+    @settingValue.setter
+    def settingValue(self, value):
         self._text.setText(self._desc, value)
-
-    settingValue = property(_value, _setValue)
 
 
 class GeneralSettings(QWidget):

--- a/puddlestuff/puddletag.py
+++ b/puddlestuff/puddletag.py
@@ -360,6 +360,11 @@ def _openFilesFilterFilename(filename):
     return filename
 
 
+# set in MainWin.__init__
+add_shortcuts = None
+remove_shortcuts = None
+
+
 class MainWin(QMainWindow):
     loadFiles = pyqtSignal(object, object, object, object, object, name='loadFiles')
     always = pyqtSignal(bool, name='always')

--- a/puddlestuff/puddletag.py
+++ b/puddlestuff/puddletag.py
@@ -1008,7 +1008,7 @@ class MainWin(QMainWindow):
                     yield None
                 except EnvironmentError as e:
                     m = translate("Dir Renaming",
-                                  'An error occured while renaming <b>%1</b> to ' \
+                                  'An error occured while renaming <b>%1</b> to '
                                   '<b>%2</b>. (%3)').arg(audio[PATH]).arg(filename).arg(e.strerror)
                     if row == rows[-1]:
                         yield m, 1

--- a/puddlestuff/shortcutsettings.py
+++ b/puddlestuff/shortcutsettings.py
@@ -199,7 +199,7 @@ class ActionEditorDialog(QWidget):
         super(ActionEditorDialog, self).__init__(parent)
         self.actions = actions
 
-        help = QLabel(translate("Shortcut Settings", '<b>Double click a cell in the Shortcut Column' \
+        help = QLabel(translate("Shortcut Settings", '<b>Double click a cell in the Shortcut Column'
                                                      ' to <br />modify the key sequence.</b>'))
 
         self.actionTable = QTableWidget(self)

--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -1022,7 +1022,7 @@ class TagModel(QAbstractTableModel):
     def setData(self, index, value, role=Qt.ItemDataRole.EditRole, dontwrite=False):
         """Sets the data of the currently edited cell as expected.
         Also writes tags and increases the undolevel."""
-        QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor);
+        QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
         if index.isValid() and 0 <= index.row() < len(self.taginfo):
             column = index.column()
             tag = self.headerdata[column][1]
@@ -1145,7 +1145,7 @@ class TagModel(QAbstractTableModel):
     def sibling(self, row, column, index=QModelIndex()):
         if row < (self.rowCount()) and row >= 0:
             return self.index(row, column)
-        return QModelIndex();
+        return QModelIndex()
 
     def sort(self, column, order=Qt.SortOrder.DescendingOrder):
         try:

--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -1593,7 +1593,7 @@ class TagTable(QTableView):
                     deltag(row)
                     yield None
                 except (OSError, IOError) as e:
-                    msg = translate('Table', "An error occurred while " \
+                    msg = translate('Table', "An error occurred while "
                                              "deleting the tag of %1: <b>%2</b>")
                     msg = msg.arg(e.filename).arg(e.strerror)
                     yield msg, len(self.selectedRows)

--- a/puddlestuff/tagsources/__init__.py
+++ b/puddlestuff/tagsources/__init__.py
@@ -101,7 +101,6 @@ def parse_searchstring(text):
         raise RetrievalError(
             translate('Tag Sources',
                       '<b>Error parsing artist/album combinations.</b>'))
-    return []
 
 
 def retrieve_cover(url):

--- a/puddlestuff/tagsources/amg.py
+++ b/puddlestuff/tagsources/amg.py
@@ -457,7 +457,7 @@ def parse_track(tr, fields, performance_title=None):
 def replace_feat(album_info, track_info):
     artist = None
     for key in ['albumartist', 'artist', 'performer', 'composer']:
-        value = album_info.get(key, '').strip();
+        value = album_info.get(key, '').strip()
         if not value.startswith('feat:'):
             artist = album_info[key]
             break

--- a/puddlestuff/tagsources/amg.py
+++ b/puddlestuff/tagsources/amg.py
@@ -105,7 +105,6 @@ def convert_year(info):
             return {'year': time.strftime('%Y-%m', year)}
         except ValueError:
             return {}
-    return {}
 
 
 def create_search(terms):

--- a/puddlestuff/tagsources/example.py
+++ b/puddlestuff/tagsources/example.py
@@ -88,13 +88,9 @@ class Example(object):
         return [(get_info(album), []) for album in releases]
 
     def retrieve(self, info):
-        if False:
-            artist = 'Alicia Keys'
-            album = 'As I Am'
-        else:
-            artist = info['artist']
-            album = info['album']
-            self.counter += 1
+        artist = info['artist']
+        album = info['album']
+        self.counter += 1
         dirpath = '%s/%s - %s' % (self.musicdir, artist, album)
         files = []
         for f in gettags(getfiles(dirpath)):

--- a/puddlestuff/tagsources/freedb.py
+++ b/puddlestuff/tagsources/freedb.py
@@ -207,8 +207,6 @@ class FreeDB(object):
             self.__retrieved[info['#discid']] = [info, tracks]
             return info, tracks
 
-        return info
-
 
 info = FreeDB
 

--- a/puddlestuff/tagsources/mp3tag/__init__.py
+++ b/puddlestuff/tagsources/mp3tag/__init__.py
@@ -211,54 +211,51 @@ class Cursor(object):
         self.stop = False
         self.track_fields = set(['track'])
 
-    def _get_char(self):
+    @property
+    def char(self):
         return self.line[self.charno]
 
-    char = property(_get_char)
-
-    def _get_debug_file(self):
+    @property
+    def debug_file(self):
         return self._debug_file
 
-    def _set_debug_file(self, filename):
+    @debug_file.setter
+    def debug_file(self, filename):
         if not filename:
             self._debug_file = None
             return
         f = open(filename, 'w')
         self._debug_file = f
 
-    debug_file = property(_get_debug_file, _set_debug_file)
-
-    def _get_field(self):
+    @property
+    def field(self):
         return self._field
 
-    def _set_field(self, value):
+    @field.setter
+    def field(self, value):
         self.output[self._field] = self.cache
         self.cache = self.output.get(value, '')
         self._field = value
 
-    field = property(_get_field, _set_field)
-
-    def _get_lineno(self):
+    @property
+    def lineno(self):
         return self._lineno
 
-    def _set_lineno(self, value):
+    @lineno.setter
+    def lineno(self, value):
         self._lineno = value
         try:
             self.line = self.all_lines[self.lineno].strip()
         except IndexError:
             self.stop = True
 
-    lineno = property(_get_lineno, _set_lineno)
-
-    def _get_lines(self):
+    @property
+    def lines(self):
         return self.all_lines[self.lineno:]
 
-    lines = property(_get_lines)
-
-    def _get_lowered(self):
+    @property
+    def lowered(self):
         return self.all_lowered[self.lineno:]
-
-    lowered = property(_get_lowered)
 
     def log(self, text):
         if self.debug and self.debug_file:

--- a/puddlestuff/tagsources/musicbrainz.py
+++ b/puddlestuff/tagsources/musicbrainz.py
@@ -488,10 +488,9 @@ class XMLEscaper(HTMLParser):
     def unknown_endtag(self, tag):
         self._xml.append('</%s>' % tag)
 
-    def _get_xml(self):
+    @property
+    def xml(self):
         return ''.join(self._xml)
-
-    xml = property(_get_xml)
 
 
 class MusicBrainz(object):

--- a/puddletag
+++ b/puddletag
@@ -53,7 +53,7 @@ def _migrate_action_shortcut_filenames():
     if not os.path.exists(filename):
         return
     with open(filename, 'r') as fo:
-        data = json.loads(fo.read());
+        data = json.loads(fo.read())
 
     old_dir = os.path.join(os.getenv('HOME'), '.puddletag', 'actions')
     for key, shortcut in data.items():


### PR DESCRIPTION
## Remove dead py2 compat code
Python 2 is dead and we don't support it anymore, so out goes the dead code.

## Remove trailing semicolon
This ain't C.

## Remove unnecessary backslashes
You can freely split the content of parenthesis across lines, no need to use backslashes.

## Remove unreachable code
Dead code is dead.

## Use property annotations
Creating properties using annotations has multiple advantages:
* They completely wrap/abstract/hide the functions, making it hard to call them directly (even internally), naturally guiding you to use it as a property.
* They directly attached to the functions, keeping things together. No more creating properties with functions defined 300 lines above. 
* They enforce their own name convention, in that the functions must have the same name as the property.
* Tools seem to understand annotation-based properties easier/better, e.g. tracking the read-/write-usages.

## Add module-level variables to fix import warnings
These two variables/functions are later defined, but need to be declared in the module for code/import checks to work properly.