### PR TITLE
Fix multi-value sort

### DIFF
--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -607,7 +607,8 @@ def natural_sort_key(s: Union[str, List[str]], case_insensitive=True) -> QCollat
     It also takes the global user preferences into account (e.g. LC_COLLATE).
     """
     if isinstance(s, list):
-        s = s[0]
+        # Join all elements with ascii unit separator
+        s = '\x1f'.join(s)
 
     locale = QLocale.system().collation() if case_insensitive else QLocale.c()
     collator = QCollator(locale)


### PR DESCRIPTION
Unfortunetly QCollator can only handle plain strings, not string lists or tuples like the python sorting. So convert the list of strings into a single string by joining the elements using a separator that's unlikely to appear in the elements: the ascii unit separator.

Fixes #816