### PR TITLE
Properly pass multi-value fields to/from functions

### DIFF
--- a/puddlestuff/audioinfo/util.py
+++ b/puddlestuff/audioinfo/util.py
@@ -564,7 +564,7 @@ def stringtags(tag, leaveNone=False):
         elif isinstance(v, (int, float)):
             newtag[i] = str(v)
         elif isinstance(i, str) and not isinstance(v, str):
-            newtag[i] = v[0]
+            newtag[i] = r'\\'.join(v)
         else:
             newtag[i] = v
     return newtag

--- a/puddlestuff/findfunc.py
+++ b/puddlestuff/findfunc.py
@@ -14,7 +14,7 @@ from pyparsing import (Word, alphas, Literal, OneOrMore, alphanums,
                        Optional)
 
 from . import audioinfo
-from .constants import ACTIONDIR, CHECKBOX, SPINBOX, SYNTAX_ERROR, SYNTAX_ARG_ERROR
+from .constants import ACTIONDIR, CHECKBOX, SEPARATOR, SPINBOX, SYNTAX_ERROR, SYNTAX_ARG_ERROR
 from .funcprint import pprint
 from .puddleobjects import PuddleConfig, safe_name
 from .util import PluginFunction, translate, to_list, to_string
@@ -613,6 +613,8 @@ def apply_actions(actions, audio, state=None, ovr_fields=None):
             if temp is None:
                 continue
             if isinstance(temp, str):
+                if SEPARATOR in temp:
+                    temp = temp.split(SEPARATOR)
                 ret[field] = temp
             elif hasattr(temp, 'items'):
                 ret.update(temp)

--- a/puddlestuff/mainwin/funcs.py
+++ b/puddlestuff/mainwin/funcs.py
@@ -16,7 +16,7 @@ from .. import musiclib, about as about
 from ..util import split_by_tag, translate, to_string
 from .. import functions
 from .tagtools import *
-from ..constants import HOMEDIR
+from ..constants import HOMEDIR, SEPARATOR
 
 path = os.path
 
@@ -455,6 +455,8 @@ def run_func(selectedfiles, func):
             for field in fields:
                 val = function(rowtags.get(field, ''), rowtags, state, r_tags=f)
                 if val is not None:
+                    if isinstance(val, str) and SEPARATOR in val:
+                        val = val.split(SEPARATOR)
                     if hasattr(val, 'items'):
                         ret.update(val)
                     else:


### PR DESCRIPTION
Before passing a field to a function, merge all of its value using the already in the UI used separator `\\`. Also split the return-value from the function into multiple values if necessary.

Fixes #818
Fixes #825