### PR TITLE
Fix masstagger gui log output

### DIFF
--- a/puddlestuff/masstag/dialogs.py
+++ b/puddlestuff/masstag/dialogs.py
@@ -7,7 +7,7 @@ from PyQt5.QtCore import QMutex, QObject, pyqtSignal
 from PyQt5.QtWidgets import QApplication, QCheckBox, QComboBox, QDialog, QGridLayout, QHBoxLayout, QLabel, \
     QLineEdit, QPushButton, QSpinBox, QTextEdit, QVBoxLayout, QWidget
 
-from .. import masstag
+from .. import masstag as masstag_module
 from ..constants import RIGHTDOCK
 from ..masstag import (NO_MATCH_OPTIONS, fields_from_text, match_files, masstag, merge_tsp_tracks,
                        split_files, MassTagFlag, MassTagProfile, TagSourceProfile)
@@ -30,7 +30,8 @@ def set_status(msg):
     QApplication.processEvents()
 
 
-masstag.set_status = set_status
+# monkey-patch the module to use the gui output
+masstag_module.set_status = set_status
 
 mutex = QMutex()
 


### PR DESCRIPTION
With the import reorg in 97f5aae5, the `set_status` function wasn't overwritten anymore, because the latter import of the `masstag` function shadowed the earlier import of the module with the same name.

Fixes #832 