### PR TITLE
Fix error on multi-value join

### DIFF
--- a/puddlestuff/audioinfo/util.py
+++ b/puddlestuff/audioinfo/util.py
@@ -563,8 +563,10 @@ def stringtags(tag, leaveNone=False):
             newtag[i] = v
         elif isinstance(v, (int, float)):
             newtag[i] = str(v)
-        elif isinstance(i, str) and not isinstance(v, str):
+        elif isinstance(v, list) and isinstance(v[0], str):
             newtag[i] = r'\\'.join(v)
+        elif isinstance(i, str) and not isinstance(v, str):
+            newtag[i] = v[0]
         else:
             newtag[i] = v
     return newtag


### PR DESCRIPTION
Bugfix for something I broke with #858. Only join multi-value fields if they are strings. As it turns out, these can also be lists of dicts, for example for images.