### PR TITLE
Fix filepath changes in preview mode

### DIFF
--- a/puddlestuff/audioinfo/util.py
+++ b/puddlestuff/audioinfo/util.py
@@ -257,6 +257,20 @@ def getinfo(filename):
     })
 
 
+def get_filename_tags(filepath: str) -> dict:
+    filepath = to_string(filepath, 'replace')
+    ret = {
+        PATH: filepath,
+        DIRPATH: path.dirname(filepath),
+        FILENAME: path.basename(filepath),
+    }
+    ret[FILENAME_NO_EXT], ret[EXTENSION] = path.splitext(ret[FILENAME])
+    ret[EXTENSION] = ret[EXTENSION][1:]  # Remove the leading dot
+    ret[DIRNAME] = path.basename(ret[DIRPATH])
+    ret[PARENT_DIR] = path.basename(path.dirname(ret[DIRPATH]))
+    return ret
+
+
 def get_mime(data):
     """Retrieve the mimetype of the image data (a bytes object).
 
@@ -740,21 +754,11 @@ class MockTag(object):
 
     def set_filepath(self, val):
         self.__filepath = path_to_string(val)
-        val = to_string(val, 'replace')
 
         if hasattr(self, 'mut_obj'):
             self.mut_obj.filename = self.__filepath
-        ret = {
-            PATH: val,
-            DIRPATH: path.dirname(val),
-            FILENAME: path.basename(val)}
 
-        ret[FILENAME_NO_EXT], ret[EXTENSION] = path.splitext(ret[FILENAME])
-        ret[EXTENSION] = ret[EXTENSION][1:]
-        ret[DIRNAME] = path.basename(ret[DIRPATH])
-        ret[PARENT_DIR] = path.basename(path.dirname(ret[DIRPATH]))
-
-        return ret
+        return get_filename_tags(to_string(val, 'replace'))
 
     filepath = property(get_filepath, set_filepath)
 
@@ -869,7 +873,7 @@ class MockTag(object):
     def stringtags(self):
         return stringtags(self)
 
-    def update(self, dictionary=None, **kwargs):
+    def update(self, dictionary=None):
         if dictionary is None:
             return
         if hasattr(dictionary, 'items'):

--- a/puddlestuff/data/menus
+++ b/puddlestuff/data/menus
@@ -1,6 +1,6 @@
 {
   "info": {
-    "version": "32"
+    "version": "33"
   }, 
   "shortcuts": {
     "__dirpath/album/track": "Alt+Meta+1"

--- a/puddlestuff/data/shortcuts
+++ b/puddlestuff/data/shortcuts
@@ -1,6 +1,6 @@
 {
   "info": {
-    "version": "32"
+    "version": "33"
   },
   "shortcut13": {
     "name": "&Text File->Tag", 
@@ -14,6 +14,7 @@
     "command": "format", 
     "control": "mainwin", 
     "enabled": "filesselected", 
+    "tooltip": "Format the selected field(s) using the pattern.",
     "status": "formatstatus"
   }, 
   "shortcut52": {
@@ -157,7 +158,7 @@
     "control": "mainwin", 
     "icon_name": "puddletag.filetotag",
     "enabled": "filesselected", 
-    "tooltip": "Convert filename to tag using the pattern.", 
+    "tooltip": "Update the selected files from their filename using the pattern.",
     "status": "ftstatus"
   }, 
   "shortcut3": {
@@ -327,6 +328,7 @@
     "command": "tag_to_file", 
     "shortcut": "Ctrl+F", 
     "icon_name": "puddletag.tagtofile",
+    "tooltip": "Rename the selected files using the pattern.",
     "status": "tfstatus"
   }, 
   "shortcut26": {

--- a/puddlestuff/loadshortcuts.py
+++ b/puddlestuff/loadshortcuts.py
@@ -8,7 +8,7 @@ from .constants import CONFIGDIR
 from .puddleobjects import PuddleConfig, get_icon, open_resourcefile
 from .translations import translate
 
-__version__ = 32
+__version__ = 33
 
 files = [open_resourcefile(filename)
          for filename in ['data:./caseconversion.action', 'data:./standard.action']]


### PR DESCRIPTION
There are multiple fields that store different parts of the filepath, like `__filename` and `__dirname`. With a real `MockTag` (like in non-preview mode) these fields are passed to the matching properties of the `MockTag` class, which in turn all (sometimes with some indirection) read/write from/to a single attribute named `__filepath`, which contains the absolute path of the file. This also means that writing one of the fields will automatically update all the others.
The preview doesn't have these properties/attribute, it is just a dict. And it wasn't treating these fields special, and didn't update the related fields. This is the reason why for example the `__filename` field, which is displayed in the table or tag panel, still showed the original value after you used the "tag to filename" function which only set the `__path` field. As soon as the preview is written, the `MockTag` implementation is used again, and the fields are properly updated again.

This implements the automatic update of the filepath fields in the preview, so it will always show what the result will be.

Also add/update some useful tooltips to explain what these ominous buttons in the UI are exactly doing (and how they differ). Thanks to #860 there is no need anymore to (re-)generate `resource.py`.

The `remove_from_preview` function was added in 5862184b but never used, so removed the dead code.

Fixes #847 