### PR TITLE
Fix iTunes stuff in MP4 and ID3

### DIFF
--- a/puddlestuff/audioinfo/constants.py
+++ b/puddlestuff/audioinfo/constants.py
@@ -27,12 +27,12 @@ IMAGETYPE = 'imagetype'
 DEFAULT_COVER = 3
 
 FIELDS = [
-    'album', 'albumsortorder', 'arranger', 'artist', 'audiodelay',
+    'album', 'albumartistsortorder', 'albumsortorder', 'arranger', 'artist', 'audiodelay',
     'audiolength', 'audiosize', 'author', 'bpm', 'comment', 'composer',
     'conductor', 'copyright', 'date', 'discnumber', 'encodedby',
     'encodingsettings', 'encodingtime', 'filename', 'fileowner', 'filetype',
     'genre', 'grouping', 'initialkey', 'involvedpeople', 'isrc',
-    'itunesalbumsortorder', 'itunescompilationflag', 'itunescomposersortorder',
+    'itunescompilationflag', 'itunescomposersortorder',
     'language', 'lyricist', 'mediatype', 'mood', 'musiciancredits',
     'organization', 'originalalbum', 'originalartist', 'originalreleasetime',
     'originalyear', 'performersortorder', 'performer', 'popularimeter',
@@ -74,11 +74,11 @@ READONLY = (PARENT_DIR, IMAGE_MIMETYPE, IMAGE_TYPE_FIELD, NUM_IMAGES,
 
 INFOTAGS = FILETAGS + list(READONLY)
 
-TEXT_FIELDS = ['album', 'albumartist', 'albumsortorder', 'arranger',
+TEXT_FIELDS = ['album', 'albumartist', 'albumartistsortorder', 'albumsortorder', 'arranger',
                'artist', 'audiodelay', 'audiolength', 'audiosize', 'author',
                'bpm', 'composer', 'conductor', 'copyright', 'date', 'discnumber',
                'encodedby', 'encodingsettings', 'filename', 'fileowner',
-               'filetype', 'grouping', 'initialkey', 'isrc', 'itunesalbumsortorder',
+               'filetype', 'grouping', 'initialkey', 'isrc',
                'itunescompilationflag', 'itunescomposersortorder', 'language',
                'lyricist', 'mediatype', 'mood', 'organization', 'originalalbum',
                'originalartist', 'originalyear', 'peformersortorder', 'producednotice',

--- a/puddlestuff/audioinfo/id3.py
+++ b/puddlestuff/audioinfo/id3.py
@@ -184,18 +184,19 @@ text_frames = {
     id3.TRSN: "radiostationname",
     id3.TRSO: "radioowner",
     id3.TSIZ: "audiosize",
+    id3.TSO2: "albumartistsortorder",
     id3.TSOA: "albumsortorder",
     id3.TSOP: "performersortorder",
     id3.TSOT: "titlesortorder",
     id3.TSRC: "isrc",
     id3.TSSE: "encodingsettings",
     id3.TSST: "setsubtitle",
-    id3.TYER: 'year'}
+    id3.TYER: 'year',
+}
 
 try:
     text_frames.update({
         id3.TCMP: "itunescompilationflag",
-        id3.TSO2: "itunesalbumsortorder",
         id3.TSOC: "itunescomposersortorder"})
 except AttributeError:
     pass

--- a/puddlestuff/audioinfo/mp4.py
+++ b/puddlestuff/audioinfo/mp4.py
@@ -43,7 +43,17 @@ TAGS = {
     'cpil': 'partofcompilation',
     'pgap': 'partofgaplessalbum',
     'pcst': 'podcast',
-    'tmpo': 'bpm'}
+    'tmpo': 'bpm',
+    'akID': 'itunesaccounttype',
+    'apID': 'itunesaccount',
+    'atID': 'itunesartistid',
+    'cmID': 'itunescomposerid',
+    'cnID': 'itunescatalogid',
+    'geID': 'itunesgenreid',
+    'plID': 'itunesalbumid',
+    'prID': 'itunesproductid',
+    'sfID': 'itunesstorecountry',
+}
 
 REVTAGS = dict([reversed(z) for z in TAGS.items()])
 
@@ -154,7 +164,17 @@ FUNCS = {
     'disc': (getint, setint),
     'totaltracks': (getint, setint),
     'totaldiscs': (getint, setint),
-    'bpm': (getint, setint)}
+    'bpm': (getint, setint),
+    'itunesaccounttype': (getint, setint),
+    'itunesaccount': (gettext, settext),
+    'itunesartistid': (getint, setint),
+    'itunescomposerid': (gettext, settext),
+    'itunescatalogid': (getint, setint),
+    'itunesgenreid': (getint, setint),
+    'itunesalbumid': (getint, setint),
+    'itunesproductid': (gettext, settext),
+    'itunesstorecountry': (getint, setint),
+}
 
 
 def bin_to_pic(cover):


### PR DESCRIPTION
## Add mp4 itunes id fields
Because they are integer fields, they require special convertion. Might as well properly map them and use human-understandable names.

Fixes #850 

## Consistently use albumartistsortorder
Nothing itunes-specific about the TSO2 frame, which is also not albumsort but albumartistsort. So rename it and use the proper name (which is already used for mp4 and wma).

Fixes #284 