### PR TITLE
Fix RuntimeError in puddleobjects.py by swallowing StopIteration exception

### DIFF
--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -642,10 +642,11 @@ def dupes(l, method=None):
 
 def getfiles(files: Union[str, List[str]], subfolders: bool = False) -> Generator[str, None, None]:
     """For the given path(s), yield all the files.
-       If path does not exist, ignore it.
-       If path is a directory, yield all the files in that directory.
-       If subfolders is True, also recurse into subdirectories and yield their files.
-       """
+
+    If path does not exist, ignore it.
+    If path is a directory, yield all the files in that directory.
+    If subfolders is True, also recurse into subdirectories and yield their files.
+    """
     if not isinstance(files, list):
         files = [files]
 
@@ -654,6 +655,7 @@ def getfiles(files: Union[str, List[str]], subfolders: bool = False) -> Generato
             continue
         if not os.path.isdir(file):
             yield file
+            continue
 
         for dirpath, dirnames, filenames in os.walk(file):
             for filename in filenames:

--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -654,26 +654,20 @@ def getfiles(files, subfolders=False):
             if not isdir(f):
                 yield f
             else:
-                try:
-                    dirname, subs, fnames = next(os.walk(f))
+                for dirname, subs, fnames in os.walk(f):
                     for fname in fnames:
                         yield join(dirname, fname)
-                except StopIteration:
-                    pass
     else:
         for f in files:
             if not isdir(f):
                 yield f
             else:
-                try:
-                    for dirname, subs, fnames in os.walk(f):
-                        for fname in fnames:
-                             yield join(dirname, fname)
-                        for sub in subs:
-                            for fname in getfiles(join(dirname, sub), subfolders):
-                                pass
-                except StopIteration:
-                    pass
+                for dirname, subs, fnames in os.walk(f):
+                    for fname in fnames:
+                         yield join(dirname, fname)
+                    for sub in subs:
+                        for fname in getfiles(join(dirname, sub), subfolders):
+                            pass
 
 
 def gettags(files):

--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -654,20 +654,26 @@ def getfiles(files, subfolders=False):
             if not isdir(f):
                 yield f
             else:
-                dirname, subs, fnames = next(os.walk(f))
-                for fname in fnames:
-                    yield join(dirname, fname)
+                try:
+                    dirname, subs, fnames = next(os.walk(f))
+                    for fname in fnames:
+                        yield join(dirname, fname)
+                except StopIteration:
+                    pass
     else:
         for f in files:
             if not isdir(f):
                 yield f
             else:
-                for dirname, subs, fnames in os.walk(f):
-                    for fname in fnames:
-                        yield join(dirname, fname)
-                    for sub in subs:
-                        for fname in getfiles(join(dirname, sub), subfolders):
-                            pass
+                try:
+                    for dirname, subs, fnames in os.walk(f):
+                        for fname in fnames:
+                             yield join(dirname, fname)
+                        for sub in subs:
+                            for fname in getfiles(join(dirname, sub), subfolders):
+                                pass
+                except StopIteration:
+                    pass
 
 
 def gettags(files):

--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -664,7 +664,7 @@ def getfiles(files, subfolders=False):
             else:
                 for dirname, subs, fnames in os.walk(f):
                     for fname in fnames:
-                         yield join(dirname, fname)
+                        yield join(dirname, fname)
                     for sub in subs:
                         for fname in getfiles(join(dirname, sub), subfolders):
                             pass


### PR DESCRIPTION
~~~
Traceback (most recent call last):
  File "/home/user/.data/miniconda3/envs/puddletag/lib/python3.12/site-packages/puddlestuff/puddleobjects.py", line 657, in getfiles
    dirname, subs, fnames = next(os.walk(f))
                            ^^^^^^^^^^^^^^^^
StopIteration

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/user/.data/miniconda3/envs/puddletag/lib/python3.12/site-packages/puddlestuff/puddleobjects.py", line 2418, in run
    self.retval = self.command()
                  ^^^^^^^^^^^^^^
  File "/home/user/.data/miniconda3/envs/puddletag/lib/python3.12/site-packages/puddlestuff/puddleobjects.py", line 875, in threadfunc
    temp = next(f)
           ^^^^^^^
  File "/home/user/.data/miniconda3/envs/puddletag/lib/python3.12/site-packages/puddlestuff/tagmodel.py", line 1905, in load_dir
    for fname in getfiles(dirs, subfolders):
RuntimeError: generator raised StopIteration
~~~