### PR TITLE
Fix delete file segfault

### DIFF
--- a/puddlestuff/audioinfo/mp4.py
+++ b/puddlestuff/audioinfo/mp4.py
@@ -124,7 +124,7 @@ def getint(value):
 
 
 def setint(value):
-    if isinstance(value, (int, int, str)):
+    if isinstance(value, (int, str)):
         return [int(value)]
     temp = []
     for z in value:

--- a/puddlestuff/audioinfo/util.py
+++ b/puddlestuff/audioinfo/util.py
@@ -564,7 +564,7 @@ def stringtags(tag, leaveNone=False):
         if i in INFOTAGS:
             newtag[i] = v
             continue
-        if isinstance(i, (int, int, float)) or hasattr(v, 'items'):
+        if isinstance(i, (int, float)) or hasattr(v, 'items'):
             continue
 
         if leaveNone and isempty(v):

--- a/puddlestuff/mainwin/tagsources.py
+++ b/puddlestuff/mainwin/tagsources.py
@@ -853,7 +853,7 @@ class MainWin(QWidget):
 
     def setResults(self, retval):
         self.searchButton.setEnabled(True)
-        if isinstance(retval, (str, str, str)):
+        if isinstance(retval, str):
             self.label.setText(retval)
         else:
             releases, files = retval

--- a/puddlestuff/mainwin/teststuff.py
+++ b/puddlestuff/mainwin/teststuff.py
@@ -80,7 +80,7 @@ class Tag(audioinfo.MockTag):
             del (self[key])
         elif key in INFOTAGS or isinstance(key, int):
             self._tags[key] = value
-        elif (key not in INFOTAGS) and isinstance(value, (str, int, int)):
+        elif (key not in INFOTAGS) and isinstance(value, (str, int)):
             self._tags[key.lower()] = [str(value)]
         else:
             self._tags[key.lower()] = [str(z) for z in value]

--- a/puddlestuff/puddleobjects.py
+++ b/puddlestuff/puddleobjects.py
@@ -851,7 +851,7 @@ def progress(func: Callable[..., Generator[Optional[Tuple[str, int]], None, None
         if maximum == 1:
             errors = next(f)
             if errors and \
-                    not isinstance(errors, (str, str, int, int, str)):
+                    not isinstance(errors, (str, int)):
                 errormsg(parent, errors[0], 1)
             if threadfin:
                 threadfin()
@@ -870,7 +870,7 @@ def progress(func: Callable[..., Generator[Optional[Tuple[str, int]], None, None
             while not win.wasCanceled:
                 try:
                     temp = next(f)
-                    if isinstance(temp, (str, str)):
+                    if isinstance(temp, str):
                         thread.message.emit(temp)
                     elif isinstance(temp, int):
                         thread.set_max.emit(temp)
@@ -901,7 +901,7 @@ def progress(func: Callable[..., Generator[Optional[Tuple[str, int]], None, None
                     except RuntimeError:
                         pass
                 return
-            elif isinstance(args[0], (str, str)):
+            elif isinstance(args[0], str):
                 if parent.showmessage:
                     ret = errormsg(parent, args[0], maximum)
                     if ret is True:

--- a/puddlestuff/tagsources/parse_html.py
+++ b/puddlestuff/tagsources/parse_html.py
@@ -35,7 +35,7 @@ class SoupWrapper(object):
             else:
                 kwargs["class"] = args[1]
         query_items = list(kwargs.items())
-        query_items = classify(query_items, lambda x: isinstance(x[1], (str, str)))
+        query_items = classify(query_items, lambda x: isinstance(x[1], str))
         regular_items = query_items.get(True, [])
         re_items = query_items.get(False, [])
         xpath_query = " and ".join(
@@ -72,7 +72,7 @@ class SoupWrapper(object):
             yield SoupWrapper(x)
 
     def __getitem__(self, idx):
-        if isinstance(idx, (str, str)):
+        if isinstance(idx, str):
             if idx in self.element.attrib:
                 return self.element.attrib[idx]
             else:

--- a/puddlestuff/util.py
+++ b/puddlestuff/util.py
@@ -266,7 +266,7 @@ def sorted_split_by_field(tracks, field='artist'):
 
 
 def to_list(value):
-    if isinstance(value, (str, int, int, float)):
+    if isinstance(value, (str, int, float)):
         value = [str(value)]
     elif isinstance(value, str):
         value = [value]
@@ -280,7 +280,7 @@ def to_string(value):
         return value.decode('utf8')
     elif isinstance(value, str):
         return value
-    elif isinstance(value, (float, int, int)):
+    elif isinstance(value, (float, int)):
         return str(value)
     else:
         return to_string(value[0])


### PR DESCRIPTION
## Consolidate isinstance types
Some isinstance calls checked multiple times for the same type, caused by the automated py2->py3 conversion. Doesn't really make a functional difference, it's mostly cosmetic aka code style.

## Fix delete file segfault
The worker function calls a non-thread-safe method of the model, which can result in a segfault. Qt provides "queued connections" for these cases to allow making such calls in a thread-safe way. Signals are one way to employ them, but they require a bit more boilerplate; for example a QObject instance to emit them. It is easier in this case to make the function call using `invokeMethod`, which will automatically "do the right thing" to make that call in a thread-safe way. While signals work
with implicit slots, in this case you need an explicit one which can simply be done with an decorator.

For more info see https://wiki.qt.io/Threads_Events_QObjects

This fix is different than the one discussed in [#894](https://github.com/puddletag/puddletag/issues/894#issuecomment-2106353770) because that has its own issues which made me reluctant to merge it; mainly the complexity.
@rambit I would appreciate it if you could test and confirm this one too.

Fixes #894