### PR TITLE
Add keywords to .desktop entry to improve findability

### DIFF
--- a/puddletag.desktop
+++ b/puddletag.desktop
@@ -7,4 +7,5 @@ MimeType=inode/directory;audio/x-ape;audio/x-wavpack;audio/x-musepack;audio/mpeg
 Exec=puddletag %F
 Icon=puddletag
 GenericName=Audio Tag Editor
-Categories=AudioVideo;Audio;Qt;
+Categories=AudioVideo;Audio;Qt;FileTools;
+Keywords=tagger;mp3tag;music;

--- a/puddletag.desktop
+++ b/puddletag.desktop
@@ -7,5 +7,5 @@ MimeType=inode/directory;audio/x-ape;audio/x-wavpack;audio/x-musepack;audio/mpeg
 Exec=puddletag %F
 Icon=puddletag
 GenericName=Audio Tag Editor
-Categories=AudioVideo;Audio;Qt;FileTools;
+Categories=AudioVideo;Audio;Qt;
 Keywords=tagger;mp3tag;music;


### PR DESCRIPTION
I added some keywords to the `.desktop` entry to improve findability of the application.  
I also added the `FileTools` category because i thought that would be adequate for this.


![image](https://github.com/puddletag/puddletag/assets/50550545/f4bf4e0f-839e-4b14-a02e-0842054a6e49)
<br>
![image](https://github.com/puddletag/puddletag/assets/50550545/21793d5e-720c-4d1d-8553-deb3382b167d)


### Resources
- https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html
- https://specifications.freedesktop.org/menu-spec/latest/apa.html & https://specifications.freedesktop.org/menu-spec/latest/apas02.html