### PR TITLE
Fix filter crash

### DIFF
--- a/puddlestuff/audio_filter.py
+++ b/puddlestuff/audio_filter.py
@@ -3,7 +3,7 @@ import logging
 import re
 
 from pyparsing import (CaselessLiteral, Combine, OpAssoc, ParserElement,
-                       QuotedString, Word, alphanums, infix_notation)
+                       ParseException, QuotedString, Word, alphanums, infix_notation)
 
 
 from . import findfunc, audioinfo


### PR DESCRIPTION
After expanding the pyparsing `*` import in 7b2a73e8, `ParserException` is no longer imported. This leads to a crash when hitting that codepath.

Fixes #929 