### PR TITLE
minor documentation tweak - update dependency install for modern debian/ubuntu

### DIFF
--- a/docs/_sources/download.txt
+++ b/docs/_sources/download.txt
@@ -34,7 +34,7 @@ Install the dependencies as listed above. For Debian-based distros, you can run 
 
 .. code-block:: bash
 
-    apt-get install python-pyqt5 python-pyparsing python-mutagen
+    apt install python3-pyqt5 python3-pyparsing python3-mutagen # qtwayland5 # if using wayland
 
 + Now download the source tarball |source_link|_ (SHA1 |source_sha|).
 + Unzip it.

--- a/docs/download.html
+++ b/docs/download.html
@@ -101,7 +101,7 @@
 <div class="section" id="installing-from-source">
 <span id="id2"></span><h2>Installing from source<a class="headerlink" href="#installing-from-source" title="Permalink to this headline">¶</a></h2>
 <p>Install the dependencies as listed above. For Debian-based distros, you can run the following as root:</p>
-<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span>apt-get install python-pyqt5 python-pyparsing python-mutagen
+<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span>apt install python3-pyqt5 python3-pyparsing python3-mutagen # qtwayland5 # if using wayland
 </pre></div>
 </div>
 <ul class="simple">

--- a/docsrc/download.txt
+++ b/docsrc/download.txt
@@ -34,7 +34,7 @@ Install the dependencies as listed above. For Debian-based distros, you can run 
 
 .. code-block:: bash
 
-    apt-get install python-pyqt5 python-pyparsing python-mutagen
+    apt install python3-pyqt5 python3-pyparsing python3-mutagen # qtwayland5 # if using wayland
 
 + Now download the source tarball |source_link|_ (SHA1 |source_sha|).
 + Unzip it.


### PR DESCRIPTION
Just a minor tweak to the docs. I wasn't sure which file is the "single source of truth" so I edited them all...

Also I wasn't sure how to best note the additional/optional "qtwayland5" wayland package? Obviously it's only a dependency if using wayland and even then, it seemed to work fine without it. On Debian 12/Bookworm it just removes this warning/error message:
```
qt.qpa.plugin: Could not find the Qt platform plugin "wayland" in ""
```