### PR TITLE
Fix empty drop on wayland

### DIFF
--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -1735,6 +1735,9 @@ class TagTable(QTableView):
                 else:
                     files.append(f)
 
+            if not dirs and not files:
+                return
+
             self.loadFiles(files, dirs, append=True)
 
     def dragMoveEvent(self, event):


### PR DESCRIPTION
With X11 (either native or XWayland) there are no drop events triggered if there is nothing dropped, while with native Wayland they are. So check and short circuit in that case, to ensure the assumptions the called code has.

Fixes #951