### PR TITLE
fix: bump requests from 2.32.0 to 2.32.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ pyqt5-sip==12.15.0
     # via pyqt5
 rapidfuzz==3.10.0
     # via levenshtein
-requests==2.32.0
+requests==2.32.3
     # via pyacoustid
 unidecode==1.3.8
     # via -r requirements.in


### PR DESCRIPTION
Fixes issue #975: failure running `pip install -r requirements.txt`
Minimal changes made; patch version of `requests` module only.