### PR TITLE
Fix wrong signal datatype in tag source widget

### DIFF
--- a/puddlestuff/mainwin/releasewidget.py
+++ b/puddlestuff/mainwin/releasewidget.py
@@ -252,7 +252,7 @@ class ChildItem(RootItem):
 class TreeModel(QtCore.QAbstractItemModel):
     retrieving = pyqtSignal(name='retrieving')
     statusChanged = pyqtSignal(str, name='statusChanged')
-    collapse = pyqtSignal(int, name='collapse')
+    collapse = pyqtSignal(QModelIndex, name='collapse')
     retrievalDone = pyqtSignal(name='retrievalDone')
     exactChanged = pyqtSignal(object, name='exactChanged')
     exactMatches = pyqtSignal(list, name='exactMatches')


### PR DESCRIPTION
Not sure if something changed since 26eda69b, or if it was just broken the whole time.

Fixes #984 