### PR TITLE
Fix appending files

### DIFF
--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -877,12 +877,15 @@ class TagModel(QAbstractTableModel):
                 getter = lambda audio: audio.get(field, '')
                 taginfo.sort(key=lambda a: natural_sort_key(a.get(field, '')), reverse=self.reverseSort)
 
-            filenames = [z.filepath for z in self.taginfo]
-            self.taginfo.extend([z for z in taginfo if z.filepath
-                                 not in filenames])
+            loaded_filenames = set(z.filepath for z in self.taginfo)
+            new_tags = [z for z in taginfo if z.filepath not in loaded_filenames]
+
+            if not new_tags:
+                return
 
             first = self.rowCount()
-            self.beginInsertRows(QModelIndex(), first, first + len(taginfo) - 1)
+            self.beginInsertRows(QModelIndex(), first, first + len(new_tags) - 1)
+            self.taginfo.extend(new_tags)
             self.endInsertRows()
 
             top = self.index(first, 0)


### PR DESCRIPTION
Fix the index calculation when appending files, properly accounting for filtered-out-because-already-loaded files. Also move the model data change inside the `*InsertRows()` function calls where it belongs. Short-circuit when there is nothing to add.

Fixes #1004