### PR TITLE
Extend system info for bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -48,6 +48,8 @@ body:
       Example:
         Puddletag: 2.0.1
         OS: Ubuntu 20.04
+        Display Server: X11
+        Desktop Environment: GNOME
         Python: 13.14.0
         PyQt: 7.6.3
 
@@ -55,6 +57,8 @@ body:
     value: |-
       Puddletag: 
       OS: 
+      Display Server: 
+      Desktop Environment: 
       Python: 
       PyQt: 
 - id: additional


### PR DESCRIPTION
In addition to the general OS info, also ask for the used display server (X11/XWayland/Wayland) and desktop environment (GNOME, KDE, MATE, Cinamon, XFCE, ...). Prefill these when using the menu function.

This is only really relevant for Linux, but lets be honest here: That's 99% of the users.