### PR TITLE
Fix new column checkstate

### DIFF
--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -464,7 +464,7 @@ class ColumnSettings(HeaderSetting):
 
     def add(self):
         HeaderSetting.add(self)
-        self.listbox.currentItem().setCheckState(True)
+        self.listbox.currentItem().setCheckState(Qt.CheckState.Checked)
 
     def duplicate(self):
         item = self.listbox.currentItem()


### PR DESCRIPTION
This bug traces back to 94ffb2a4, so it was apparently allowed to pass a boolean to `setCheckState(CheckState)` with PyQt5 and older, but not with PyQt6 anymore. This is also the last/only occurrence of such usage.

Not to be confused with the isChecked/setChecked of QCheckbox, which do take a (bi-state) boolean as a simpler alternative to the tri-state CheckState enum. But QListWidgetItem does not support that simpler api.

Fixes #1016