### PR TITLE
Add context-aware identical scripting

### DIFF
--- a/docsrc/source/scripting.txt
+++ b/docsrc/source/scripting.txt
@@ -71,6 +71,15 @@ The scripting functions that puddletag supports are listed here. Use them where 
 
    If string a is longer than string b, then x is returned, otherwise y.
 
+.. describe:: $identical(tagname)
+
+   Returns ``1`` when every currently selected file shares the same value for *tagname* and ``0`` otherwise. The argument can be a bare tag name such as ``albumartist`` or a field reference like ``%albumartist%``. puddletag uses the active selection from the tag grid, so the function is aware of multi-directory selections and treats missing values as mismatches.
+
+   Manual verification (Album Artist example):
+
+   #. Select all tracks from a single album where ``Album Artist`` is populated the same on every row, run :menuselection:`Actions --> Format value` (or any pattern entry point) with a temporary field set to ``$identical(%albumartist%)``, and confirm the preview shows ``1``.
+   #. Extend the selection with another directory that either leaves ``Album Artist`` blank or contains a different value, rerun the same action, and confirm the result flips to ``0`` to signal the mixed context.
+
 
 .. describe:: $isdigit(x)
 

--- a/puddlestuff/context.py
+++ b/puddlestuff/context.py
@@ -1,0 +1,16 @@
+"""Shared context helpers for puddletag."""
+from typing import Iterable, List, Optional
+
+_selected_files: List = []
+
+def set_selected_files(files: Optional[Iterable]) -> None:
+    """Store the current selection of files for global access."""
+    global _selected_files
+    if files is None:
+        _selected_files = []
+    else:
+        _selected_files = list(files)
+
+def get_selected_files() -> List:
+    """Return the last recorded selection of files."""
+    return _selected_files

--- a/puddlestuff/functions.py
+++ b/puddlestuff/functions.py
@@ -46,8 +46,10 @@ from unidecode import unidecode
 import pyparsing
 
 from . import audioinfo
+from . import context
 from .audioinfo import encode_fn
 from .puddleobjects import (safe_name, fnmatch, natural_sort_key)
+from .util import to_string
 
 PATH = audioinfo.PATH
 DIRPATH = audioinfo.DIRPATH
@@ -73,6 +75,43 @@ def _pad(text, numlen):
     if len(text) < numlen:
         text = _padding * ((numlen - len(text)) // len(_padding)) + text
     return text
+
+
+def identical(p_tagname=None, state=None):
+    '''Identical, Returns True if all selected files have the same value for the given tagname.
+&Tag name or %field%, text'''
+    selected = None
+    if not p_tagname:
+        raise FuncError('Tag name required for $identical.')
+    if state is not None:
+        selected = state.get('__selectedfiles')
+    if not selected:
+        selected = context.get_selected_files()
+    if not selected:
+        return false
+    tagname = to_string(p_tagname)
+    if tagname.startswith('%') and tagname.endswith('%') and len(tagname) > 2:
+        tagname = tagname[1:-1]
+    values = []
+    missing_value = False
+    for tags in selected:
+        try:
+            value = tags.get(tagname, None)
+        except AttributeError:
+            value = getattr(tags, tagname, None)
+        if value is None:
+            missing_value = True
+            continue
+        values.append(value)
+    if not values:
+        return false
+    if missing_value:
+        return false
+    first = values[0]
+    for v in values[1:]:
+        if v != first:
+            return false
+    return true
 
 
 def autonumbering(r_tags, minimum=1, restart=False, padding=1, state=None):
@@ -1050,6 +1089,7 @@ def validate(text, to=None, chars=None):
 
 
 functions = {
+        "identical": identical,
     "add": add,
     "and": and_,
     'artwork': load_images,

--- a/puddlestuff/mainwin/funcs.py
+++ b/puddlestuff/mainwin/funcs.py
@@ -38,6 +38,8 @@ def applyaction(files=None, funcs=None):
         return
     state = {'__total_files': str(len(files))}
     state['__files'] = files
+    # Add all selected file tags to state for group-aware scripting
+    state['__selectedfiles'] = files
 
     def func():
         for i, f in enumerate(files):
@@ -54,6 +56,8 @@ def applyquickaction(files, funcs):
 
     selected = status['selectedtags']
     state = {'__total_files': str(len(selected))}
+    state['__files'] = files
+    state['__selectedfiles'] = files
     t = (qa(funcs, f, state, list(s.keys())) for f, s in zip(files, selected))
     emit('writeselected', t)
 

--- a/puddlestuff/tagmodel.py
+++ b/puddlestuff/tagmodel.py
@@ -29,6 +29,7 @@ from .constants import SELECTIONCHANGED, SEPARATOR, BLANK
 from . import confirmations
 import logging
 from .translations import translate
+from . import context
 from .util import rename_error_msg
 from .audio_filter import parse as filter_audio
 
@@ -2254,6 +2255,8 @@ class TagTable(QTableView):
                 self.filesselected.emit(False)
             model.highlight(self.selectedRows)
             self.tagselectionchanged.emit()
+        # keep global context aware of current selection for scripting
+        context.set_selected_files(self.selectedTags)
 
     def saveBeforeReset(self):
         self.setCursor(Qt.CursorShape.BusyCursor)


### PR DESCRIPTION
For the longest time I've wished that puddletag could evaluate the contents of  a tag across multiple files so that one can incorporate more intelligence in scripting.  $identical() is the first of what may be a few functions I'd like to add